### PR TITLE
Fix error when user()->first() is null in DiscussionBestAnswerPage.php

### DIFF
--- a/src/Page/DiscussionBestAnswerPage.php
+++ b/src/Page/DiscussionBestAnswerPage.php
@@ -150,7 +150,7 @@ class DiscussionBestAnswerPage implements PageDriverInterface
             'dateCreated' => $seoMeta->created_at,
             'author' => [
                 "@type" => "Person",
-                "name" => $discussion->user() ? $discussion->user()->first()->getDisplayNameAttribute() : null
+                "name" => ($discussion->user() && !is_null($discussion->user()->first())) ? $discussion->user()->first()->getDisplayNameAttribute() : null
             ],
             'answerCount' => $discussion->comment_count - 1
         ];


### PR DESCRIPTION
Fix to avoid error message when $discussion->user()->first() is null.