### PR TITLE
fix: add missing `flarum/tags` as optional dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,9 @@
     "flarum-extension": {
       "title": "SEO",
       "category": "feature",
+      "optional-dependencies": [
+        "flarum/tags"
+      ],
       "icon": {
         "name": "fas fa-check",
         "backgroundColor": "#0072ff",


### PR DESCRIPTION
The extension will fail to initialize in some cases