### PR TITLE
chore: add workflows

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,16 @@
+name: V17 Seo JS
+
+on: [workflow_dispatch, push, pull_request]
+
+jobs:
+  run:
+    uses: flarum/framework/.github/workflows/REUSABLE_frontend.yml@1.x
+    with:
+      enable_bundlewatch: false
+      enable_prettier: false
+      enable_typescript: false
+
+      frontend_directory: ./js
+      backend_directory: .
+      js_package_manager: npm
+      main_git_branch: master


### PR DESCRIPTION
This PR introduces the frontend workflow, which is common standard in Flarum Extensions. As it is configured now, it will automatically build the JS Bundle when a JS change is pushed to the default branch, in this case `master`.  This removes the need to manually build the Bundle.

