### PR TITLE
fix: change condition of early return in best answer page

### DIFF
--- a/src/Page/DiscussionBestAnswerPage.php
+++ b/src/Page/DiscussionBestAnswerPage.php
@@ -116,7 +116,7 @@ class DiscussionBestAnswerPage implements PageDriverInterface
         /** @var Collection<Tag> $discussionTags */
         $discussionTags = $discussion->tags;
 
-        if ($enableBestAnswer && $discussionTags->contains(fn(Tag $tag) => (bool)$tag->is_qna )) {
+        if (!$enableBestAnswer || !$discussionTags->contains(fn(Tag $tag) => (bool)$tag->is_qna )) {
             $this->discussionFallback->handle($request, $properties);
             return;
         }


### PR DESCRIPTION
The if statement currently wrongly early returns when best answer is enabled and a tag of a discussion is a QNA tag, this must be the other way around.