### PR TITLE
fix: do-follow links should not carry rel="ugc"

### DIFF
--- a/src/Formatter/FormatLinks.php
+++ b/src/Formatter/FormatLinks.php
@@ -47,8 +47,11 @@ class FormatLinks
         return Utils::replaceAttributes($xml, 'URL', function (array $attributes): array {
             $domain = $this->urlToDomain($attributes['url']);
 
-            // Do we add a nofollow?
-            $attributes['rel'] = 'ugc noopener'.($this->addNofollow($domain) ? ' nofollow' : '');
+            // Do-follow domains (the forum itself + the configured allow-list)
+            // should pass ranking signals, so they get neither `nofollow` nor
+            // `ugc` (Google treats `ugc` as a nofollow hint too). Untrusted
+            // user-generated links get both.
+            $attributes['rel'] = $this->addNofollow($domain) ? 'ugc noopener nofollow' : 'noopener';
 
             // Open link in new tab
             if (!isset($attributes['target'])) {

--- a/tests/integration/formatter/FormatLinksTest.php
+++ b/tests/integration/formatter/FormatLinksTest.php
@@ -86,7 +86,10 @@ class FormatLinksTest extends TestCase
 
         $html = $this->postReplyAndGetContentHtml('Check https://trusted.test/page out.');
 
+        // GH #113 — do-follow links must pass ranking signals: no nofollow and
+        // no ugc (which Google also treats as nofollow).
         $this->assertStringNotContainsString('nofollow', $html);
+        $this->assertStringNotContainsString('ugc', $html);
         $this->assertStringContainsString('target="_blank"', $html);
     }
 

--- a/tests/unit/Formatter/FormatLinksTest.php
+++ b/tests/unit/Formatter/FormatLinksTest.php
@@ -38,12 +38,16 @@ class FormatLinksTest extends TestCase
 
         $result = $formatter->__invoke(m::mock(Renderer::class), null, $xml);
 
-        $this->assertStringContainsString('rel="ugc noopener"', $result);
+        // Do-follow links (the forum's own domain) must pass ranking signals:
+        // no `nofollow`, and no `ugc` (which Google also treats as nofollow).
+        $this->assertStringContainsString('rel="noopener"', $result);
+        $this->assertStringNotContainsString('ugc', $result);
         $this->assertStringNotContainsString('nofollow', $result);
     }
 
     /**
-     * External links on a domain not in the do-follow list receive nofollow.
+     * External links on a domain not in the do-follow list receive `ugc` and
+     * `nofollow` (untrusted user-generated content).
      */
     public function test_external_link_gets_nofollow(): void
     {
@@ -53,11 +57,12 @@ class FormatLinksTest extends TestCase
 
         $result = $formatter->__invoke(m::mock(Renderer::class), null, $xml);
 
-        $this->assertStringContainsString('nofollow', $result);
+        $this->assertStringContainsString('rel="ugc noopener nofollow"', $result);
     }
 
     /**
-     * Domains listed in the do-follow setting should not receive nofollow.
+     * Domains on the do-follow list must pass ranking signals — no `nofollow`
+     * and no `ugc` (GH #113).
      */
     public function test_dofollow_listed_external_link_does_not_get_nofollow(): void
     {
@@ -70,6 +75,8 @@ class FormatLinksTest extends TestCase
 
         $result = $formatter->__invoke(m::mock(Renderer::class), null, $xml);
 
+        $this->assertStringContainsString('rel="noopener"', $result);
+        $this->assertStringNotContainsString('ugc', $result);
         $this->assertStringNotContainsString('nofollow', $result);
     }
 


### PR DESCRIPTION
External links to **do-follow** domains (the forum's own domain and the configured allow-list) were still rendered with `rel="ugc noopener"`. Google treats `ugc` as a nofollow hint, so those links never passed ranking signals — defeating the purpose of the do-follow list.

Do-follow domains now render with `rel="noopener"` (no `ugc`, no `nofollow`). Untrusted external links are unchanged (`rel="ugc noopener nofollow"`).

Closes #113.
