### PR TITLE
fix: include the forum name in the WebSite schema

### DIFF
--- a/src/Listeners/PageListener.php
+++ b/src/Listeners/PageListener.php
@@ -205,6 +205,7 @@ class PageListener
         return [
             '@context'        => 'http://schema.org',
             '@type'           => 'WebSite',
+            'name'            => $this->settings->get('forum_title'),
             'url'             => $this->applicationUrl.'/',
             'potentialAction' => [
                 '@type'       => 'SearchAction',

--- a/tests/integration/forum/SchemaJsonLdTest.php
+++ b/tests/integration/forum/SchemaJsonLdTest.php
@@ -32,6 +32,20 @@ class SchemaJsonLdTest extends ForumHtmlTestCase
     }
 
     /**
+     * The WebSite entry must carry the forum name so search engines display it
+     * (rather than the bare domain). Regression lock for GH #115.
+     *
+     * @test
+     */
+    public function website_entry_includes_the_forum_name(): void
+    {
+        $website = $this->findSchemaEntry($this->fetchForumHtml('/'), 'WebSite');
+
+        $this->assertNotNull($website);
+        $this->assertSame('Example Forum', $website['name'] ?? null);
+    }
+
+    /**
      * @test
      */
     public function every_forum_page_emits_the_website_search_action_entry(): void


### PR DESCRIPTION
The `WebSite` JSON-LD block didn't include a `name`, so Google fell back to displaying the bare domain in search results instead of the forum name (`og:site_name` alone wasn't enough).

The `WebSite` entry now includes the forum title as its `name`.

Closes #115.
