### PR TITLE
fix: emit QAPage for discussions in a child of a Q&A tag

### DIFF
--- a/src/Page/DiscussionBestAnswerPage.php
+++ b/src/Page/DiscussionBestAnswerPage.php
@@ -86,7 +86,8 @@ class DiscussionBestAnswerPage implements PageDriverInterface
         $discussionTags = $discussion->tags;
 
         // Not a Q&A discussion — DiscussionPage already emitted DiscussionForumPosting.
-        if (!$discussionTags->contains(fn (Tag $tag) => (bool) $tag->is_qna)) {
+        // A child of a Q&A tag counts as Q&A too (flarum-tags nests one level).
+        if (!$discussionTags->contains(fn (Tag $tag) => (bool) $tag->is_qna || (bool) $tag->parent?->is_qna)) {
             return;
         }
 

--- a/src/Page/DiscussionPage.php
+++ b/src/Page/DiscussionPage.php
@@ -82,7 +82,7 @@ class DiscussionPage implements PageDriverInterface
         // DiscussionForumPosting here.
         if (
             $this->settingsRepositoryInterface->get('seo_post_crawler', 0) == 1 &&
-            $tagsEnabled && $enableBestAnswer && $discussionTags->contains(fn (Tag $tag) => (bool) $tag->is_qna)
+            $tagsEnabled && $enableBestAnswer && $discussionTags->contains(fn (Tag $tag) => (bool) $tag->is_qna || (bool) $tag->parent?->is_qna)
         ) {
             return;
         }

--- a/tests/integration/forum/BestAnswerPageTest.php
+++ b/tests/integration/forum/BestAnswerPageTest.php
@@ -109,6 +109,42 @@ class BestAnswerPageTest extends ForumHtmlTestCase
     }
 
     /**
+     * A discussion tagged only with a *child* of a Q&A tag should still be
+     * treated as Q&A and emit a QAPage. Regression lock for GH #108.
+     *
+     * @test
+     */
+    public function qa_page_emitted_for_discussion_in_child_of_qna_tag(): void
+    {
+        $this->setting('seo_post_crawler', '1');
+
+        $now = Carbon::now();
+
+        $this->prepareDatabase([
+            'tags' => [
+                ['id' => 10, 'name' => 'Support', 'slug' => 'support', 'description' => null, 'color' => '#000', 'position' => 0, 'is_restricted' => false, 'is_hidden' => false, 'is_qna' => true],
+                ['id' => 11, 'name' => 'Install', 'slug' => 'install', 'description' => null, 'color' => '#000', 'position' => 0, 'parent_id' => 10, 'is_restricted' => false, 'is_hidden' => false, 'is_qna' => false],
+            ],
+            'discussions' => [
+                ['id' => 1, 'title' => 'How to install?', 'slug' => 'how-to-install', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 2, 'best_answer_post_id' => 2, 'created_at' => $now, 'last_posted_at' => $now],
+            ],
+            'posts' => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>How?</p></t>', 'created_at' => $now],
+                ['id' => 2, 'discussion_id' => 1, 'number' => 2, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Like this.</p></t>', 'created_at' => $now],
+            ],
+            // Tagged only with the child tag (#11), whose parent (#10) is the Q&A tag.
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => 11],
+            ],
+        ]);
+
+        $this->assertNotNull(
+            $this->findSchemaEntry($this->fetchForumHtml('/d/1-how-to-install'), 'QAPage'),
+            'A discussion in a child of a Q&A tag should emit a QAPage.'
+        );
+    }
+
+    /**
      * @test
      */
     public function qa_page_marks_accepted_and_suggested_answers(): void


### PR DESCRIPTION
Q&A detection only looked at each of a discussion's *own* tags for `is_qna`. A discussion tagged with a **child** (secondary) tag whose parent is the Q&A tag was therefore treated as non-Q&A and rendered as `DiscussionForumPosting` instead of `QAPage`.

The check now also honours the parent tag's `is_qna` (flarum-tags nests one level), in both the `DiscussionPage` defer condition and the `DiscussionBestAnswerPage` driver.

Closes #108.
