### PR TITLE
fix: pick up protocol-relative image URLs for the social image

### DIFF
--- a/src/Listeners/PageListener.php
+++ b/src/Listeners/PageListener.php
@@ -366,15 +366,16 @@ class PageListener
     {
         // Check post content is not empty
         if ($content !== null) {
-            // Read Post content and filter image url
-            $pattern = '/(?<=src=")((http.*?\.)(jpe?g|png|[tg]iff?|svg|webp)(\?[a-zA-Z0-9\_\-\=\&]*)?)(?=")/';
+            // Match http(s) and protocol-relative ("//host/img.png") image URLs.
+            $pattern = '/(?<=src=")((?:https?:)?\/\/.*?\.)(jpe?g|png|[tg]iff?|svg|webp)(\?[a-zA-Z0-9\_\-\=\&]*)?(?=")/';
 
             // Use image from post for social media og:image
-            if (preg_match_all($pattern, $content, $matches) && count($matches) > 0) {
+            if (preg_match_all($pattern, $content, $matches)) {
                 $contentImage = $matches[0][0];
 
-                if ($contentImage !== null) {
-                    return $contentImage;
+                if ($contentImage !== '') {
+                    // Normalise protocol-relative URLs so og:image is absolute.
+                    return str_starts_with($contentImage, '//') ? 'https:'.$contentImage : $contentImage;
                 }
             }
         }

--- a/tests/unit/Listeners/PageListenerTest.php
+++ b/tests/unit/Listeners/PageListenerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of fof/seo.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Seo\Tests\unit\Listeners;
+
+use Flarum\Http\UrlGenerator;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Testing\unit\TestCase;
+use FoF\Seo\Listeners\PageListener;
+use FoF\Seo\Page\PageManager;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Filesystem\Cloud;
+use Mockery as m;
+
+class PageListenerTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        m::close();
+        parent::tearDown();
+    }
+
+    private function makeListener(): PageListener
+    {
+        $forumUrl = m::mock();
+        $forumUrl->shouldReceive('base')->andReturn('https://forum.example.com');
+
+        $url = m::mock(UrlGenerator::class);
+        $url->shouldReceive('to')->with('forum')->andReturn($forumUrl);
+
+        $filesystem = m::mock();
+        $filesystem->shouldReceive('disk')->with('flarum-assets')->andReturn(m::mock(Cloud::class));
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('filesystem')->andReturn($filesystem);
+
+        return new PageListener(
+            m::mock(SettingsRepositoryInterface::class),
+            $url,
+            m::mock(PageManager::class),
+            m::mock(Dispatcher::class),
+            $container,
+        );
+    }
+
+    public function test_getImageFromContent_extracts_an_absolute_image_url(): void
+    {
+        $result = $this->makeListener()->getImageFromContent('<p><img src="https://i.imgur.com/abc.png"></p>');
+
+        $this->assertSame('https://i.imgur.com/abc.png', $result);
+    }
+
+    /**
+     * GH #72 — protocol-relative image URLs (`//host/img.png`) must be picked
+     * up and normalised to an absolute https URL for og:image.
+     */
+    public function test_getImageFromContent_handles_protocol_relative_url(): void
+    {
+        $result = $this->makeListener()->getImageFromContent('<p><img src="//i.imgur.com/abc.png"></p>');
+
+        $this->assertSame('https://i.imgur.com/abc.png', $result);
+    }
+
+    public function test_getImageFromContent_returns_null_when_there_is_no_image(): void
+    {
+        $result = $this->makeListener()->getImageFromContent('<p>No images here, just text.</p>');
+
+        $this->assertNull($result);
+    }
+}


### PR DESCRIPTION
`getImageFromContent` only matched image URLs beginning with `http(s)`, so a post using a **protocol-relative** source (`//i.imgur.com/x.png`) never had its image picked up for `og:image` / `twitter:image`.

It now also matches protocol-relative URLs and normalises them to `https://…` so the resulting `og:image` is always absolute.

Closes #72.
