### PR TITLE
feat: option to de-index profile pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Methods used:
   - [CollectionPage](https://schema.org/CollectionPage) — with an `ItemList` of the tag's discussions
   - [ProfilePage](https://schema.org/ProfilePage) — with a rich `Person` (identity + activity stats)
 - Uses the first image in the post as the social-media image when one is present, falling back to the configured default.
+- Optional **indexing controls** — e.g. de-index user profile pages (`noindex, follow`) to keep thin pages out of search results.
 
 > Your `robots.txt` and XML sitemap are provided by [fof/sitemap](https://github.com/FriendsOfFlarum/sitemap). See [Sitemap & robots.txt](https://github.com/FriendsOfFlarum/seo/blob/1.x/docs/sitemap-and-robots.md).
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -30,6 +30,7 @@ of months.
 | **Twitter card size** | Whether shared links render as a large image card (`summary_large_image`) or a small summary card (`summary`). |
 | **Social media image** | The image used when a page is shared on Facebook, Twitter/X, Reddit, etc. A square 1200×1200 image is recommended; otherwise a 1200×630 landscape image. Falls back to your logo, then favicon. |
 | **Discussion post crawl settings** | Whether search engines index only the first post of a discussion (default) or all posts. See below. |
+| **De-index profile pages** | When enabled, user profile pages emit `noindex, follow` so thin profile pages are kept out of search results. See below. |
 | **No-follow / do-follow links** | External links get `rel="nofollow"` by default; manage exceptions in the [do-follow list](do-follow-links.md). |
 | **Open external links in new tab** | External links open in a new tab. (Always on.) |
 
@@ -40,6 +41,19 @@ You can switch to indexing **all posts** in a discussion, which gives search
 engines more context (and, with [fof/best-answer](https://github.com/FriendsOfFlarum/best-answer)
 installed, lets them surface the answer) at some extra rendering cost. Choose
 based on how much load your server can handle.
+
+### Indexing controls
+
+**De-index profile pages** keeps user profiles (`/u/*`) out of search results.
+Profile pages are often thin, near-duplicate content, and dropping them can raise
+the overall proportion of "quality" pages a search engine indexes. When enabled,
+profiles emit `<meta name="robots" content="noindex, follow">` — the `follow`
+keeps crawlers traversing the links on the page, which is the recommended
+treatment for low-value pages you want out of the index.
+
+> `robots.txt`-level rules (e.g. `Disallow: /u/`) are handled by
+> [fof/sitemap](sitemap-and-robots.md); this setting controls the per-page
+> `robots` meta tag.
 
 ## What gets rendered
 

--- a/js/src/admin/components/Forms/SeoSettings.tsx
+++ b/js/src/admin/components/Forms/SeoSettings.tsx
@@ -5,6 +5,7 @@ import Button from 'flarum/common/components/Button';
 import LinkButton from 'flarum/common/components/LinkButton';
 import Link from 'flarum/common/components/Link';
 import Select from 'flarum/common/components/Select';
+import Switch from 'flarum/common/components/Switch';
 import UploadImageButton from 'flarum/admin/components/UploadImageButton';
 import saveSettings from 'flarum/admin/utils/saveSettings';
 import Stream from 'flarum/common/utils/Stream';
@@ -152,6 +153,24 @@ export default class SeoSettings extends Component {
         </Button>
       </FieldSet>,
       50
+    );
+
+    items.add(
+      'noindexProfiles',
+      <FieldSet
+        label={app.translator.trans('fof-seo.admin.settings.indexing.heading')}
+        className={this.showField !== 'all' ? 'hidden' : ''}
+      >
+        <div className="helpText">{app.translator.trans('fof-seo.admin.settings.indexing.profiles_help')}</div>
+        <Switch
+          state={app.data.settings.seo_noindex_profiles === '1'}
+          loading={this.saving}
+          onchange={(value: boolean) => this.saveSingleSetting('seo_noindex_profiles', value ? '1' : '0')}
+        >
+          {app.translator.trans('fof-seo.admin.settings.indexing.profiles_label')}
+        </Switch>
+      </FieldSet>,
+      45
     );
 
     items.add(

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -70,6 +70,11 @@ fof-seo:
         help: This is an important setting about crawling your discussion posts in search results.
         button: Setup post crawl settings
 
+      indexing:
+        heading: Indexing controls
+        profiles_label: De-index profile pages
+        profiles_help: When enabled, user profile pages emit a 'noindex' meta tag so they are kept out of search results. Links on the page are still followed, so crawlers can still reach the content they point to.
+
       nofollow:
         heading: No-follow links
         help: All links to external domains will receive a '<i>nofollow</i>' attribute by default. This will make sure people do not spam your forum with links to other domains in order to get more referrals.

--- a/src/Page/ProfilePage.php
+++ b/src/Page/ProfilePage.php
@@ -11,6 +11,7 @@
 
 namespace FoF\Seo\Page;
 
+use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\User\UserRepository;
 use FoF\Seo\SeoProperties;
 use Illuminate\Support\Arr;
@@ -22,6 +23,7 @@ class ProfilePage implements PageDriverInterface
     public function __construct(
         protected readonly UserRepository $userRepository,
         protected readonly TranslatorInterface $translator,
+        protected readonly SettingsRepositoryInterface $settings,
     ) {
     }
 
@@ -131,5 +133,11 @@ class ProfilePage implements PageDriverInterface
 
             // Canonical url
             ->setCanonicalUrl('/u/'.$user->getAttribute('username'));
+
+        // Optionally keep thin profile pages out of the search index (GH #62).
+        // Links are still followed so crawlers can reach the content they link to.
+        if ($this->settings->get('seo_noindex_profiles')) {
+            $properties->setMetaTag('robots', 'noindex, follow');
+        }
     }
 }

--- a/tests/integration/forum/ProfilePageTest.php
+++ b/tests/integration/forum/ProfilePageTest.php
@@ -164,6 +164,49 @@ class ProfilePageTest extends ForumHtmlTestCase
     }
 
     /**
+     * Profiles inherit the site-wide `index, follow` robots default unless the
+     * admin opts to deindex them (GH #62).
+     *
+     * @test
+     */
+    public function profile_pages_are_indexable_by_default(): void
+    {
+        $html = $this->fetchForumHtml('/u/victorinox');
+
+        $this->assertSame('index, follow', $this->findMetaByName($html, 'robots'));
+    }
+
+    /**
+     * When `seo_noindex_profiles` is enabled, profile pages emit
+     * `noindex, follow` so thin profile pages drop out of the index while
+     * crawlers still follow the links on them (GH #62).
+     *
+     * @test
+     */
+    public function profile_pages_are_noindexed_when_the_setting_is_enabled(): void
+    {
+        $this->setting('seo_noindex_profiles', '1');
+
+        $html = $this->fetchForumHtml('/u/victorinox');
+
+        $this->assertSame('noindex, follow', $this->findMetaByName($html, 'robots'));
+    }
+
+    /**
+     * Explicitly disabling the setting keeps profiles indexable.
+     *
+     * @test
+     */
+    public function disabling_the_noindex_setting_keeps_profiles_indexable(): void
+    {
+        $this->setting('seo_noindex_profiles', '0');
+
+        $html = $this->fetchForumHtml('/u/victorinox');
+
+        $this->assertSame('index, follow', $this->findMetaByName($html, 'robots'));
+    }
+
+    /**
      * @test
      */
     public function missing_profile_does_not_crash_the_seo_extension(): void


### PR DESCRIPTION
Adds an admin toggle to keep user profile pages out of search results, addressing #62.

## What

- New \`seo_noindex_profiles\` setting (default **off**).
- When enabled, profile pages (\`/u/*\`) emit \`<meta name="robots" content="noindex, follow">\`.
- \`follow\` is kept so crawlers still traverse the links on the profile (the recommended treatment for low-value pages you want out of the index).
- Admin UI: a new **Indexing controls** section in the SEO settings with a toggle.

The original issue also mentioned `Disallow: /u/` in robots.txt — that file is now produced by [fof/sitemap](https://github.com/FriendsOfFlarum/sitemap), so the meta tag is the part that belongs in this extension.

## Tests

- Profiles are indexable by default.
- Profiles emit \`noindex, follow\` when the setting is enabled.
- Explicitly disabling the setting keeps them indexable.

Closes #62