### PR TITLE
feat: exclude discussions in chosen tags from indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Methods used:
   - [CollectionPage](https://schema.org/CollectionPage) — with an `ItemList` of the tag's discussions
   - [ProfilePage](https://schema.org/ProfilePage) — with a rich `Person` (identity + activity stats)
 - Uses the first image in the post as the social-media image when one is present, falling back to the configured default.
-- Optional **indexing controls** — e.g. de-index user profile pages (`noindex, follow`) to keep thin pages out of search results.
+- Optional **indexing controls** — de-index user profile pages, or whole tags (and their discussions), with `noindex, follow` to keep thin/low-value pages out of search results.
 
 > Your `robots.txt` and XML sitemap are provided by [fof/sitemap](https://github.com/FriendsOfFlarum/sitemap). See [Sitemap & robots.txt](https://github.com/FriendsOfFlarum/seo/blob/1.x/docs/sitemap-and-robots.md).
 

--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,10 @@
   "require": {
     "php": "^8.2",
     "flarum/core": "^1.8.0",
+    "flarum/tags": "^1.8",
     "ext-json": "*"
   },
   "require-dev": {
-    "flarum/tags": "^1.8",
     "flarum/likes": "^1.8",
     "fof/pages": "^1.0",
     "fof/best-answer": "^1.7",

--- a/docs/features.md
+++ b/docs/features.md
@@ -31,6 +31,7 @@ of months.
 | **Social media image** | The image used when a page is shared on Facebook, Twitter/X, Reddit, etc. A square 1200×1200 image is recommended; otherwise a 1200×630 landscape image. Falls back to your logo, then favicon. |
 | **Discussion post crawl settings** | Whether search engines index only the first post of a discussion (default) or all posts. See below. |
 | **De-index profile pages** | When enabled, user profile pages emit `noindex, follow` so thin profile pages are kept out of search results. See below. |
+| **De-index tags** | Discussions in chosen tags — and those tags' own listing pages — emit `noindex, follow`. Requires [flarum/tags](https://github.com/flarum/tags). See below. |
 | **No-follow / do-follow links** | External links get `rel="nofollow"` by default; manage exceptions in the [do-follow list](do-follow-links.md). |
 | **Open external links in new tab** | External links open in a new tab. (Always on.) |
 
@@ -54,6 +55,13 @@ treatment for low-value pages you want out of the index.
 > `robots.txt`-level rules (e.g. `Disallow: /u/`) are handled by
 > [fof/sitemap](sitemap-and-robots.md); this setting controls the per-page
 > `robots` meta tag.
+
+**De-index tags** (shown when [flarum/tags](https://github.com/flarum/tags) is
+enabled) lets you pick tags whose content should stay out of the index. Every
+discussion in a selected tag, and the tag's own listing page, emits
+`noindex, follow`. Selecting a parent tag also covers its child tags. Excluding
+low-value or noisy sections this way raises the overall proportion of quality
+pages a search engine indexes, which can help the rest of the forum rank.
 
 ## What gets rendered
 

--- a/js/src/admin/components/Forms/NoindexTagsSetting.tsx
+++ b/js/src/admin/components/Forms/NoindexTagsSetting.tsx
@@ -3,6 +3,10 @@ import Component from 'flarum/common/Component';
 import Button from 'flarum/common/components/Button';
 import LoadingIndicator from 'flarum/common/components/LoadingIndicator';
 import saveSettings from 'flarum/admin/utils/saveSettings';
+// @ts-ignore - resolved from flarum/tags at runtime; this component is only rendered when that extension is enabled.
+import TagSelectionModal from 'flarum/tags/components/TagSelectionModal';
+// @ts-ignore
+import tagsLabel from 'flarum/tags/helpers/tagsLabel';
 import type Mithril from 'mithril';
 
 /**
@@ -10,10 +14,9 @@ import type Mithril from 'mithril';
  * should be kept out of the search index — the `seo_noindex_tags` setting
  * consumed by the page drivers (GH #117).
  *
- * Reuses flarum/tags' own `TagSelectionModal` for the picker. flarum/tags is an
- * optional dependency, so its exports are resolved at runtime rather than via a
- * static import (which would break the admin bundle when tags is disabled).
- * This component is only rendered when flarum/tags is enabled.
+ * Reuses flarum/tags' own `TagSelectionModal` for the picker. The selection is
+ * persisted as a JSON array of tag IDs. Only rendered when flarum/tags is
+ * enabled (see SeoSettings#tagsEnabled).
  */
 export default class NoindexTagsSetting extends Component {
   loading: boolean = true;
@@ -51,7 +54,7 @@ export default class NoindexTagsSetting extends Component {
       <div className="SeoNoindexTags">
         <div className="SeoNoindexTags-selection">
           {selected.length > 0 ? (
-            this.renderLabels(selected)
+            tagsLabel(selected)
           ) : (
             <span className="helpText">{app.translator.trans('fof-seo.admin.settings.indexing.tags_none_selected')}</span>
           )}
@@ -63,21 +66,11 @@ export default class NoindexTagsSetting extends Component {
     );
   }
 
-  renderLabels(tags: any[]): Mithril.Children {
-    const tagsLabel = this.tagsCompat('tags/helpers/tagsLabel');
-
-    return tagsLabel ? tagsLabel(tags) : tags.map((tag) => tag.name()).join(', ');
-  }
-
   selectedTags(): any[] {
     return this.selectedIds.map((id) => this.tagsById[id]).filter(Boolean);
   }
 
   openModal() {
-    const TagSelectionModal = this.tagsCompat('tags/components/TagSelectionModal');
-
-    if (!TagSelectionModal) return;
-
     app.modal.show(TagSelectionModal, {
       selectedTags: this.selectedTags(),
       canSelect: () => true,
@@ -111,14 +104,5 @@ export default class NoindexTagsSetting extends Component {
     } catch {
       return [];
     }
-  }
-
-  /**
-   * Resolve an export from flarum/tags' compat registry at runtime, returning
-   * undefined if the extension isn't loaded.
-   */
-  tagsCompat(key: string): any {
-    // @ts-ignore - `flarum` is a global provided by the platform.
-    return typeof flarum !== 'undefined' ? flarum.extensions?.['flarum-tags']?.[key] : undefined;
   }
 }

--- a/js/src/admin/components/Forms/NoindexTagsSetting.tsx
+++ b/js/src/admin/components/Forms/NoindexTagsSetting.tsx
@@ -1,0 +1,124 @@
+import app from 'flarum/admin/app';
+import Component from 'flarum/common/Component';
+import Button from 'flarum/common/components/Button';
+import LoadingIndicator from 'flarum/common/components/LoadingIndicator';
+import saveSettings from 'flarum/admin/utils/saveSettings';
+import type Mithril from 'mithril';
+
+/**
+ * Lets admins pick tags whose discussions (and the tags' own listing pages)
+ * should be kept out of the search index — the `seo_noindex_tags` setting
+ * consumed by the page drivers (GH #117).
+ *
+ * Reuses flarum/tags' own `TagSelectionModal` for the picker. flarum/tags is an
+ * optional dependency, so its exports are resolved at runtime rather than via a
+ * static import (which would break the admin bundle when tags is disabled).
+ * This component is only rendered when flarum/tags is enabled.
+ */
+export default class NoindexTagsSetting extends Component {
+  loading: boolean = true;
+  saving: boolean = false;
+  selectedIds: string[] = [];
+  tagsById: Record<string, any> = {};
+
+  oninit(vnode: Mithril.Vnode<{}, this>) {
+    super.oninit(vnode);
+
+    this.selectedIds = this.parseSelected().map(String);
+
+    (app.store.find('tags', { include: 'parent' }) as Promise<any>)
+      .then((tags: any) => {
+        (Array.isArray(tags) ? tags : []).forEach((tag: any) => {
+          this.tagsById[String(tag.id())] = tag;
+        });
+        this.loading = false;
+        m.redraw();
+      })
+      .catch(() => {
+        this.loading = false;
+        m.redraw();
+      });
+  }
+
+  view() {
+    if (this.loading) {
+      return <LoadingIndicator />;
+    }
+
+    const selected = this.selectedTags();
+
+    return (
+      <div className="SeoNoindexTags">
+        <div className="SeoNoindexTags-selection">
+          {selected.length > 0 ? (
+            this.renderLabels(selected)
+          ) : (
+            <span className="helpText">{app.translator.trans('fof-seo.admin.settings.indexing.tags_none_selected')}</span>
+          )}
+        </div>
+        <Button className="Button" loading={this.saving} onclick={() => this.openModal()}>
+          {app.translator.trans('fof-seo.admin.settings.indexing.tags_button')}
+        </Button>
+      </div>
+    );
+  }
+
+  renderLabels(tags: any[]): Mithril.Children {
+    const tagsLabel = this.tagsCompat('tags/helpers/tagsLabel');
+
+    return tagsLabel ? tagsLabel(tags) : tags.map((tag) => tag.name()).join(', ');
+  }
+
+  selectedTags(): any[] {
+    return this.selectedIds.map((id) => this.tagsById[id]).filter(Boolean);
+  }
+
+  openModal() {
+    const TagSelectionModal = this.tagsCompat('tags/components/TagSelectionModal');
+
+    if (!TagSelectionModal) return;
+
+    app.modal.show(TagSelectionModal, {
+      selectedTags: this.selectedTags(),
+      canSelect: () => true,
+      onsubmit: (selected: any[]) => this.save(selected),
+    });
+  }
+
+  save(selected: any[]) {
+    selected.forEach((tag) => {
+      this.tagsById[String(tag.id())] = tag;
+    });
+
+    this.selectedIds = selected.map((tag) => String(tag.id()));
+    this.saving = true;
+
+    const value = JSON.stringify(this.selectedIds.map((id) => parseInt(id, 10)));
+
+    saveSettings({ seo_noindex_tags: value })
+      .then(() => app.alerts.show({ type: 'success' }, app.translator.trans('core.admin.settings.saved_message')))
+      .catch(() => {})
+      .then(() => {
+        this.saving = false;
+        m.redraw();
+      });
+  }
+
+  parseSelected(): Array<number | string> {
+    try {
+      const parsed = JSON.parse(app.data.settings.seo_noindex_tags || '[]');
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Resolve an export from flarum/tags' compat registry at runtime, returning
+   * undefined if the extension isn't loaded.
+   */
+  tagsCompat(key: string): any {
+    // @ts-ignore - `flarum` is a global provided by the platform.
+    return typeof flarum !== 'undefined' ? flarum.extensions?.['flarum-tags']?.[key] : undefined;
+  }
+}

--- a/js/src/admin/components/Forms/SeoSettings.tsx
+++ b/js/src/admin/components/Forms/SeoSettings.tsx
@@ -15,6 +15,7 @@ import type Mithril from 'mithril';
 
 import CrawlPostModal from '../Modals/CrawlPostModal';
 import DoFollowListModal from '../Modals/DoFollowListModal';
+import NoindexTagsSetting from './NoindexTagsSetting';
 import countKeywords from '../../utils/countKeywords';
 
 const SETTING_FIELDS = ['forum_title', 'forum_description', 'forum_keywords', 'seo_twitter_card_size'] as const;
@@ -156,7 +157,7 @@ export default class SeoSettings extends Component {
     );
 
     items.add(
-      'noindexProfiles',
+      'indexingControls',
       <FieldSet
         label={app.translator.trans('fof-seo.admin.settings.indexing.heading')}
         className={this.showField !== 'all' ? 'hidden' : ''}
@@ -169,6 +170,13 @@ export default class SeoSettings extends Component {
         >
           {app.translator.trans('fof-seo.admin.settings.indexing.profiles_label')}
         </Switch>
+
+        {this.tagsEnabled() && (
+          <div className="SeoNoindexTags-section" style={{ marginTop: '15px' }}>
+            <div className="helpText">{app.translator.trans('fof-seo.admin.settings.indexing.tags_help')}</div>
+            <NoindexTagsSetting />
+          </div>
+        )}
       </FieldSet>,
       45
     );
@@ -230,6 +238,14 @@ export default class SeoSettings extends Component {
 
   changed(): boolean {
     return SETTING_FIELDS.some((key) => this.values[key]() !== app.data.settings[key]);
+  }
+
+  tagsEnabled(): boolean {
+    try {
+      return JSON.parse(app.data.settings.extensions_enabled || '[]').includes('flarum-tags');
+    } catch {
+      return false;
+    }
   }
 
   onsubmit(e: SubmitEvent) {

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -74,6 +74,9 @@ fof-seo:
         heading: Indexing controls
         profiles_label: De-index profile pages
         profiles_help: When enabled, user profile pages emit a 'noindex' meta tag so they are kept out of search results. Links on the page are still followed, so crawlers can still reach the content they point to.
+        tags_help: Discussions in the selected tags (and those tags' own listing pages) will be kept out of search results with a 'noindex' meta tag. Links are still followed. Selecting a parent tag also covers its child tags.
+        tags_button: Select tags
+        tags_none_selected: No tags excluded from indexing.
 
       nofollow:
         heading: No-follow links

--- a/src/Page/DiscussionBestAnswerPage.php
+++ b/src/Page/DiscussionBestAnswerPage.php
@@ -24,6 +24,7 @@ use Flarum\User\User;
 use Flarum\User\UserRepository;
 use FoF\Seo\SeoMeta\SeoMeta;
 use FoF\Seo\SeoProperties;
+use FoF\Seo\TagIndexingPolicy;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
@@ -40,6 +41,7 @@ class DiscussionBestAnswerPage implements PageDriverInterface
         protected readonly UrlGenerator $urlGenerator,
         Dispatcher $events,
         protected readonly SlugManager $slugManager,
+        protected readonly TagIndexingPolicy $tagIndexingPolicy,
     ) {
         $this->events = $events;
     }
@@ -217,5 +219,11 @@ class DiscussionBestAnswerPage implements PageDriverInterface
         }
 
         $properties->setSchemaJson('mainEntity', $mainEntity);
+
+        // Keep discussions in admin-excluded tags out of the index (GH #117).
+        // Overrides the robots directive set by generateTagsFromMetaData above.
+        if ($this->tagIndexingPolicy->shouldNoindex($discussionTags)) {
+            $properties->setMetaTag('robots', 'noindex, follow');
+        }
     }
 }

--- a/src/Page/DiscussionPage.php
+++ b/src/Page/DiscussionPage.php
@@ -24,6 +24,7 @@ use Flarum\User\User;
 use Flarum\User\UserRepository;
 use FoF\Seo\SeoMeta\SeoMeta;
 use FoF\Seo\SeoProperties;
+use FoF\Seo\TagIndexingPolicy;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
@@ -40,6 +41,7 @@ class DiscussionPage implements PageDriverInterface
         protected readonly UrlGenerator $urlGenerator,
         Dispatcher $events,
         protected readonly SlugManager $slugManager,
+        protected readonly TagIndexingPolicy $tagIndexingPolicy,
     ) {
         $this->events = $events;
     }
@@ -188,6 +190,12 @@ class DiscussionPage implements PageDriverInterface
                     'url'  => $this->urlGenerator->to('forum')->route('tag', ['slug' => $tag->slug]),
                 ])->toArray()
             );
+        }
+
+        // Keep discussions in admin-excluded tags out of the index (GH #117).
+        // Overrides the robots directive set by generateTagsFromMetaData above.
+        if ($tagsEnabled && $this->tagIndexingPolicy->shouldNoindex($discussionTags)) {
+            $properties->setMetaTag('robots', 'noindex, follow');
         }
     }
 }

--- a/src/Page/TagPage.php
+++ b/src/Page/TagPage.php
@@ -15,6 +15,7 @@ use Flarum\Foundation\DispatchEventsTrait;
 use Flarum\Tags\TagRepository;
 use FoF\Seo\SeoMeta\SeoMeta;
 use FoF\Seo\SeoProperties;
+use FoF\Seo\TagIndexingPolicy;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
@@ -27,6 +28,7 @@ class TagPage implements PageDriverInterface
     public function __construct(
         protected readonly TranslatorInterface $translator,
         Dispatcher $events,
+        protected readonly TagIndexingPolicy $tagIndexingPolicy,
     ) {
         $this->events = $events;
     }
@@ -97,5 +99,11 @@ class TagPage implements PageDriverInterface
             'numberOfItems'   => count($itemListElement),
             'itemListElement' => $itemListElement,
         ]);
+
+        // Keep the listing page of an admin-excluded tag out of the index (GH #117).
+        // Overrides the robots directive set by generateTagsFromMetaData above.
+        if ($this->tagIndexingPolicy->shouldNoindex([$tag])) {
+            $properties->setMetaTag('robots', 'noindex, follow');
+        }
     }
 }

--- a/src/TagIndexingPolicy.php
+++ b/src/TagIndexingPolicy.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of fof/seo.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Seo;
+
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Tags\Tag;
+
+/**
+ * Decides whether a page should be kept out of the search index because it
+ * belongs to a tag the admin has excluded (GH #117). Centralises the logic so
+ * the discussion, best-answer and tag page drivers stay in agreement.
+ */
+class TagIndexingPolicy
+{
+    public function __construct(
+        protected readonly SettingsRepositoryInterface $settings,
+    ) {
+    }
+
+    /**
+     * The tag IDs the admin has excluded from indexing.
+     *
+     * @return array<int, int>
+     */
+    public function excludedTagIds(): array
+    {
+        $raw = $this->settings->get('seo_noindex_tags');
+
+        if (empty($raw)) {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map('intval', $decoded)));
+    }
+
+    /**
+     * Whether any of the given tags (or their parent) is excluded. A child of
+     * an excluded tag counts as excluded too — flarum-tags nests one level.
+     *
+     * @param iterable<Tag> $tags
+     */
+    public function shouldNoindex(iterable $tags): bool
+    {
+        $excluded = $this->excludedTagIds();
+
+        if (empty($excluded)) {
+            return false;
+        }
+
+        foreach ($tags as $tag) {
+            if (in_array((int) $tag->id, $excluded, true)) {
+                return true;
+            }
+
+            $parentId = $tag->parent_id ?? $tag->parent?->id;
+
+            if ($parentId !== null && in_array((int) $parentId, $excluded, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/integration/forum/NoindexTagsTest.php
+++ b/tests/integration/forum/NoindexTagsTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * This file is part of fof/seo.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Seo\Tests\integration\forum;
+
+use Carbon\Carbon;
+use FoF\Seo\Tests\integration\ForumHtmlTestCase;
+
+/**
+ * Admins can keep every discussion in chosen tags (and those tags' own listing
+ * pages) out of the search index via the `seo_noindex_tags` setting (GH #117).
+ */
+class NoindexTagsTest extends ForumHtmlTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-seo');
+        $this->extension('flarum-tags');
+
+        $this->setting('forum_title', 'Example Forum');
+
+        $this->prepareDatabase([
+            'tags' => [
+                ['id' => 1, 'name' => 'Parent', 'slug' => 'parent', 'description' => null, 'color' => '#000', 'position' => 0, 'is_restricted' => false, 'is_hidden' => false],
+                ['id' => 2, 'name' => 'Child', 'slug' => 'child', 'description' => null, 'color' => '#000', 'position' => 1, 'is_restricted' => false, 'is_hidden' => false, 'parent_id' => 1],
+                ['id' => 3, 'name' => 'Unrelated', 'slug' => 'unrelated', 'description' => null, 'color' => '#000', 'position' => 2, 'is_restricted' => false, 'is_hidden' => false],
+            ],
+            'discussions' => [
+                ['id' => 1, 'title' => 'In unrelated tag', 'slug' => 'in-unrelated', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'created_at' => Carbon::now()],
+                ['id' => 2, 'title' => 'In parent tag', 'slug' => 'in-parent', 'user_id' => 1, 'first_post_id' => 2, 'comment_count' => 1, 'created_at' => Carbon::now()],
+                ['id' => 3, 'title' => 'In child tag', 'slug' => 'in-child', 'user_id' => 1, 'first_post_id' => 3, 'comment_count' => 1, 'created_at' => Carbon::now()],
+            ],
+            'posts' => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Body.</p></t>', 'created_at' => Carbon::now()],
+                ['id' => 2, 'discussion_id' => 2, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Body.</p></t>', 'created_at' => Carbon::now()],
+                ['id' => 3, 'discussion_id' => 3, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Body.</p></t>', 'created_at' => Carbon::now()],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => 3],
+                ['discussion_id' => 2, 'tag_id' => 1],
+                ['discussion_id' => 3, 'tag_id' => 2],
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function discussions_are_indexable_when_no_tags_are_excluded(): void
+    {
+        $html = $this->fetchForumHtml('/d/1-in-unrelated');
+
+        $this->assertSame('index, follow', $this->findMetaByName($html, 'robots'));
+    }
+
+    /**
+     * A discussion tagged with an excluded tag is de-indexed.
+     *
+     * @test
+     */
+    public function discussion_in_an_excluded_tag_is_noindexed(): void
+    {
+        $this->setting('seo_noindex_tags', json_encode([3]));
+
+        $html = $this->fetchForumHtml('/d/1-in-unrelated');
+
+        $this->assertSame('noindex, follow', $this->findMetaByName($html, 'robots'));
+    }
+
+    /**
+     * A discussion in a tag that is *not* excluded stays indexable even when
+     * other tags are excluded.
+     *
+     * @test
+     */
+    public function discussion_outside_excluded_tags_stays_indexable(): void
+    {
+        $this->setting('seo_noindex_tags', json_encode([3]));
+
+        $html = $this->fetchForumHtml('/d/2-in-parent');
+
+        $this->assertSame('index, follow', $this->findMetaByName($html, 'robots'));
+    }
+
+    /**
+     * Excluding a parent tag also de-indexes discussions in its child tags
+     * (flarum-tags nests one level).
+     *
+     * @test
+     */
+    public function discussion_in_a_child_of_an_excluded_tag_is_noindexed(): void
+    {
+        $this->setting('seo_noindex_tags', json_encode([1]));
+
+        $html = $this->fetchForumHtml('/d/3-in-child');
+
+        $this->assertSame('noindex, follow', $this->findMetaByName($html, 'robots'));
+    }
+
+    /**
+     * The excluded tag's own listing page is de-indexed too.
+     *
+     * @test
+     */
+    public function the_excluded_tag_listing_page_is_noindexed(): void
+    {
+        $this->setting('seo_noindex_tags', json_encode([3]));
+
+        $html = $this->fetchForumHtml('/t/unrelated');
+
+        $this->assertSame('noindex, follow', $this->findMetaByName($html, 'robots'));
+    }
+
+    /**
+     * A child tag whose parent is excluded has its listing page de-indexed.
+     *
+     * @test
+     */
+    public function child_tag_listing_page_of_excluded_parent_is_noindexed(): void
+    {
+        $this->setting('seo_noindex_tags', json_encode([1]));
+
+        $html = $this->fetchForumHtml('/t/child');
+
+        $this->assertSame('noindex, follow', $this->findMetaByName($html, 'robots'));
+    }
+
+    /**
+     * A tag that is not excluded keeps its listing page indexable.
+     *
+     * @test
+     */
+    public function non_excluded_tag_listing_page_stays_indexable(): void
+    {
+        $this->setting('seo_noindex_tags', json_encode([3]));
+
+        $html = $this->fetchForumHtml('/t/parent');
+
+        $this->assertSame('index, follow', $this->findMetaByName($html, 'robots'));
+    }
+}

--- a/tests/unit/TagIndexingPolicyTest.php
+++ b/tests/unit/TagIndexingPolicyTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of fof/seo.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Seo\Tests\unit;
+
+use Flarum\Settings\SettingsRepositoryInterface;
+use Flarum\Testing\unit\TestCase;
+use FoF\Seo\TagIndexingPolicy;
+use Mockery as m;
+
+class TagIndexingPolicyTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        m::close();
+        parent::tearDown();
+    }
+
+    private function policy(mixed $settingValue): TagIndexingPolicy
+    {
+        $settings = m::mock(SettingsRepositoryInterface::class);
+        $settings->shouldReceive('get')->with('seo_noindex_tags')->andReturn($settingValue);
+
+        return new TagIndexingPolicy($settings);
+    }
+
+    private function tag(int $id, ?int $parentId = null, ?object $parent = null): object
+    {
+        return (object) ['id' => $id, 'parent_id' => $parentId, 'parent' => $parent];
+    }
+
+    public function test_excludedTagIds_is_empty_when_unset(): void
+    {
+        $this->assertSame([], $this->policy(null)->excludedTagIds());
+        $this->assertSame([], $this->policy('')->excludedTagIds());
+    }
+
+    public function test_excludedTagIds_is_empty_for_invalid_json(): void
+    {
+        $this->assertSame([], $this->policy('not json')->excludedTagIds());
+    }
+
+    public function test_excludedTagIds_is_empty_when_json_is_not_an_array(): void
+    {
+        $this->assertSame([], $this->policy('5')->excludedTagIds());
+    }
+
+    public function test_excludedTagIds_parses_and_normalises_ids(): void
+    {
+        // Strings are cast to int and falsy/zero values dropped.
+        $this->assertSame([1, 2, 3], $this->policy(json_encode([1, 2, 3]))->excludedTagIds());
+        $this->assertSame([1, 2], $this->policy(json_encode(['1', '2']))->excludedTagIds());
+        $this->assertSame([4], $this->policy(json_encode([0, 4]))->excludedTagIds());
+    }
+
+    public function test_shouldNoindex_is_false_when_nothing_excluded(): void
+    {
+        $this->assertFalse($this->policy(null)->shouldNoindex([$this->tag(1)]));
+    }
+
+    public function test_shouldNoindex_matches_a_tag_id_directly(): void
+    {
+        $policy = $this->policy(json_encode([3]));
+
+        $this->assertTrue($policy->shouldNoindex([$this->tag(3)]));
+        $this->assertFalse($policy->shouldNoindex([$this->tag(9)]));
+    }
+
+    public function test_shouldNoindex_matches_via_parent_id_column(): void
+    {
+        $policy = $this->policy(json_encode([1]));
+
+        // Child tag with parent_id = 1 (excluded).
+        $this->assertTrue($policy->shouldNoindex([$this->tag(2, 1)]));
+    }
+
+    public function test_shouldNoindex_matches_via_loaded_parent_relation(): void
+    {
+        $policy = $this->policy(json_encode([1]));
+
+        // parent_id null, but the loaded parent relation has the excluded id.
+        $this->assertTrue($policy->shouldNoindex([$this->tag(2, null, (object) ['id' => 1])]));
+    }
+
+    public function test_shouldNoindex_is_false_when_no_tag_or_parent_matches(): void
+    {
+        $policy = $this->policy(json_encode([99]));
+
+        $this->assertFalse($policy->shouldNoindex([$this->tag(2, 1)]));
+    }
+}


### PR DESCRIPTION
Lets admins keep every discussion in chosen tags — and those tags' own listing pages — out of search results, addressing #117.

## What

- New \`seo_noindex_tags\` setting (a JSON array of tag IDs).
- Discussions in any listed tag, and the tag's own listing page, emit \`<meta name="robots" content="noindex, follow">\`. Links are still followed so crawlers reach the content they point to.
- Selecting a **parent** tag also covers its child tags (flarum-tags nests one level).
- The logic lives in a single \`TagIndexingPolicy\` so the discussion, best-answer and tag-page drivers stay in agreement.
- Admin UI: an **Indexing controls** section that reuses flarum/tags' own \`TagSelectionModal\` for the picker (resolved at runtime, so the admin bundle is safe when tags is disabled). Only shown when flarum/tags is enabled.

## Tests

- Unit: \`TagIndexingPolicy\` — JSON parsing edge cases, direct/parent-id/loaded-parent matching.
- Integration: discussion in excluded tag → \`noindex\`; discussion outside → \`index\`; child-of-excluded-parent → \`noindex\`; excluded tag's listing page → \`noindex\`; child listing of excluded parent → \`noindex\`; non-excluded tag page stays \`index\`.

Also live-tested against a forum: a discussion tagged *Bugs* and \`/t/bugs\` both returned \`noindex, follow\` with the tag excluded, while unaffected pages stayed \`index, follow\`.

Closes #117