### PR TITLE
feat: expose per-reply upvotes in DiscussionForumPosting comment[]

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Methods used:
 - `inLanguage` on every page
 - Schema.org structured data:
   - [WebPage](https://schema.org/WebPage) + [WebSite](https://schema.org/WebSite) `SearchAction`
-  - [DiscussionForumPosting](https://schema.org/DiscussionForumPosting) — with `headline`, `text` and comment/like/view [interactionStatistic](https://schema.org/interactionStatistic)s
+  - [DiscussionForumPosting](https://schema.org/DiscussionForumPosting) — with `headline`, `text`, comment/like/view [interactionStatistic](https://schema.org/interactionStatistic)s, and (with post crawling on) per-reply `comment` nodes carrying like/upvote counts
   - [QAPage](https://schema.org/QAPage) for Q&A discussions (with `fof/best-answer`)
   - [CollectionPage](https://schema.org/CollectionPage) — with an `ItemList` of the tag's discussions
   - [ProfilePage](https://schema.org/ProfilePage) — with a rich `Person` (identity + activity stats)
@@ -79,6 +79,7 @@ Compatible — but not required — alongside:
 - [flarum/likes](https://github.com/flarum/likes) — like counts in the interaction statistics
 - [flarum/tags](https://github.com/flarum/tags)
 - [fof/best-answer](https://github.com/FriendsOfFlarum/best-answer) — Q&A (`QAPage`) structured data
+- [fof/gamification](https://github.com/FriendsOfFlarum/gamification) — per-reply upvote counts in the structured data
 - [fof/sitemap](https://github.com/FriendsOfFlarum/sitemap) — sitemap & robots.txt
 - [fof/pages](https://github.com/FriendsOfFlarum/pages)
 - [fof/discussion-views](https://github.com/FriendsOfFlarum/discussion-views) — view counts in the structured data

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     "flarum/likes": "^1.8",
     "fof/pages": "^1.0",
     "fof/best-answer": "^1.7",
+    "fof/gamification": "*",
     "flarum/phpstan": "^1.0",
     "flarum/testing": "^1.0.0",
     "fof/discussion-views": "*",

--- a/docs/features.md
+++ b/docs/features.md
@@ -43,6 +43,13 @@ engines more context (and, with [fof/best-answer](https://github.com/FriendsOfFl
 installed, lets them surface the answer) at some extra rendering cost. Choose
 based on how much load your server can handle.
 
+With this enabled, each reply is also emitted as a schema.org `comment`
+(`Comment`) node on the `DiscussionForumPosting`, carrying its own approval
+count as a `LikeAction`. The count combines [flarum/likes](https://github.com/flarum/likes)
+likes and [fof/gamification](https://github.com/FriendsOfFlarum/gamification)
+upvotes when either (or both) is enabled — so search engines can tell the
+standout replies apart even when you don't use the best-answer extension.
+
 ### Indexing controls
 
 **De-index profile pages** keeps user profiles (`/u/*`) out of search results.
@@ -77,7 +84,7 @@ The JSON-LD is tailored per page type and carries `inLanguage` on every page:
 | Page | schema.org type | Notable properties |
 | --- | --- | --- |
 | Index | `WebPage` + `WebSite` | `publisher`, `SearchAction` (sitelinks search box) |
-| Discussion | `DiscussionForumPosting` | `author`, `headline`, `text`, `datePublished`/`dateModified`, breadcrumb, and `interactionStatistic` for comments, likes and views |
+| Discussion | `DiscussionForumPosting` | `author`, `headline`, `text`, `datePublished`/`dateModified`, breadcrumb, `interactionStatistic` for comments, likes and views, and (with post crawling on) a `comment[]` of replies each with their like/upvote count |
 | Q&A discussion | `QAPage` | `Question` with `acceptedAnswer`/`suggestedAnswer`, `upvoteCount`, `answerCount` (needs fof/best-answer) |
 | Tag | `CollectionPage` | `name`, and a `mainEntity` `ItemList` of the tag's recent discussions |
 | User profile | `ProfilePage` | `Person` with `alternateName`, `identifier`, `agentInteractionStatistic` (posts/discussions) |
@@ -94,7 +101,8 @@ configuration needed:
 - **[fof/discussion-views](https://github.com/FriendsOfFlarum/discussion-views)** — adds a view-count `ViewAction` to discussion structured data.
 - **[fof/discussion-language](https://github.com/FriendsOfFlarum/discussion-language)** — sets `inLanguage` per discussion from its assigned language (multi-language forums).
 - **[fof/best-answer](https://github.com/FriendsOfFlarum/best-answer)** — renders Q&A discussions as a `QAPage`.
-- **[flarum/likes](https://github.com/flarum/likes)** — adds like counts to the interaction statistics.
+- **[flarum/likes](https://github.com/flarum/likes)** — adds like counts to the interaction statistics, including per-reply `LikeAction` counts when post crawling is on.
+- **[fof/gamification](https://github.com/FriendsOfFlarum/gamification)** — adds per-reply upvote counts to the `comment[]` `LikeAction`s (combined with likes when both are enabled).
 
 Developers can add their own data via the `PreparingPageMeta` event — see
 [Extending & intercepting the metadata](developers/extending-metadata.md).

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -30,7 +30,7 @@ fof-seo:
         mode_main_title: Only index the main post (default)
         mode_main_help: Search engine will only show the main post in the search results. It won't affect loading speed when you navigate to it via forum links.
         mode_all_title: Index all posts in a discussion (setting enabled)
-        mode_all_help: Search engines will understand the discussions and are even able to show some relevant posts underneath the search results. When you have the extension '<a>best answer</a>' installed and enabled on your forum, it will mark the discussion as 'answered' on the search results and redirect the user to that specific post. <b>However, depending on your server settings, this can be heavier</b>. It may cost some performance, so it depends on how fast your server is to enable this feature.
+        mode_all_help: Search engines will understand the discussions and are even able to show some relevant posts underneath the search results. When you have the extension '<a>best answer</a>' installed and enabled on your forum, it will mark the discussion as 'answered' on the search results and redirect the user to that specific post. Each reply is also exposed with its like and upvote counts, so search engines can identify the most helpful answers even without the best answer extension. <b>However, depending on your server settings, this can be heavier</b>. It may cost some performance, so it depends on how fast your server is to enable this feature.
         question: Do you want to enable this feature?
         switch_label: "Crawl all posts (it's slower on page refresh, but search results will be better)"
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,11 +9,13 @@ parameters:
     - vendor/flarum/tags/extend.php
     - vendor/flarum/likes/extend.php
     - vendor/fof/best-answer/extend.php
+    - vendor/fof/gamification/extend.php
   excludePaths:
     analyse:
       - *.blade.php
       - vendor/flarum/tags/extend.php
       - vendor/flarum/likes/extend.php
       - vendor/fof/best-answer/extend.php
+      - vendor/fof/gamification/extend.php
   checkMissingIterableValueType: false
   databaseMigrationsPath: ['migrations']

--- a/src/Page/DiscussionPage.php
+++ b/src/Page/DiscussionPage.php
@@ -18,6 +18,7 @@ use Flarum\Foundation\DispatchEventsTrait;
 use Flarum\Http\SlugManager;
 use Flarum\Http\UrlGenerator;
 use Flarum\Post\CommentPost;
+use Flarum\Post\Post;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Tags\Tag;
 use Flarum\User\User;
@@ -73,6 +74,8 @@ class DiscussionPage implements PageDriverInterface
 
         $tagsEnabled = $this->extensionManager->isEnabled('flarum-tags');
         $enableBestAnswer = $this->extensionManager->isEnabled('fof-best-answer');
+        $enableLikes = $this->extensionManager->isEnabled('flarum-likes');
+        $enableGamification = $this->extensionManager->isEnabled('fof-gamification');
 
         /** @var Collection<Tag> $discussionTags */
         $discussionTags = $discussion->tags;
@@ -153,17 +156,86 @@ class DiscussionPage implements PageDriverInterface
                 $properties->setSchemaJson('text', $text);
             }
 
-            // Like count as a LikeAction interaction, when likes are available.
-            if ($this->extensionManager->isEnabled('flarum-likes')) {
+            // Like/upvote count as a LikeAction interaction. Combines flarum/likes
+            // and fof/gamification upvotes when either (or both) is enabled.
+            if ($enableLikes || $enableGamification) {
                 $interactionStatistic[] = [
                     '@type'                => 'InteractionCounter',
                     'interactionType'      => 'https://schema.org/LikeAction',
-                    'userInteractionCount' => $firstPost->likes()->count(),
+                    'userInteractionCount' => $this->approvalCount($firstPost, $enableLikes, $enableGamification),
                 ];
             }
         }
 
         $properties->setSchemaJson('interactionStatistic', $interactionStatistic);
+
+        // Expose replies as schema.org Comment nodes (each with its like/upvote
+        // count) when post crawling is enabled. This restores the per-reply
+        // approval signal search engines use to surface standout replies (GH #130),
+        // using the standards-compliant DiscussionForumPosting > comment structure.
+        if ($this->settingsRepositoryInterface->get('seo_post_crawler', 0) == 1) {
+            $countRelations = [];
+
+            if ($enableLikes) {
+                $countRelations[] = 'likes';
+            }
+
+            if ($enableGamification) {
+                $countRelations[] = 'upvotes';
+            }
+
+            /** @var Collection<Post> $replies */
+            $replies = $discussion->posts()
+                ->where('number', '>', 1)
+                ->where('type', 'comment')
+                ->where('is_private', false)
+                ->with('user')
+                ->withCount($countRelations)
+                ->orderBy('number')
+                ->get();
+
+            $comments = $replies->map(function (Post $post) use ($discussion, $enableLikes, $enableGamification) {
+                $comment = [
+                    '@type'       => 'Comment',
+                    'text'        => trim(strip_tags($post->content)),
+                    'dateCreated' => $post->created_at->toIso8601String(),
+                    'url'         => $this->urlGenerator->to('forum')->route('discussion', ['id' => $discussion->id.'-'.$discussion->slug, 'near' => $post->number]),
+                ];
+
+                // Author, when the post still has one (skip for deleted users).
+                if ($post->user !== null) {
+                    $comment['author'] = [
+                        '@type' => 'Person',
+                        'name'  => $post->user->getAttribute('display_name'),
+                        'url'   => $this->urlGenerator->to('forum')->route('user', ['username' => $this->slugManager->forResource(User::class)->toSlug($post->user)]),
+                    ];
+                }
+
+                if ($enableLikes || $enableGamification) {
+                    $count = 0;
+
+                    if ($enableLikes) {
+                        $count += (int) $post->getAttribute('likes_count');
+                    }
+
+                    if ($enableGamification) {
+                        $count += (int) $post->getAttribute('upvotes_count');
+                    }
+
+                    $comment['interactionStatistic'] = [
+                        '@type'                => 'InteractionCounter',
+                        'interactionType'      => 'https://schema.org/LikeAction',
+                        'userInteractionCount' => $count,
+                    ];
+                }
+
+                return $comment;
+            })->toArray();
+
+            if (count($comments) > 0) {
+                $properties->setSchemaJson('comment', $comments);
+            }
+        }
 
         try {
             // Add author to the page meta data
@@ -197,5 +269,25 @@ class DiscussionPage implements PageDriverInterface
         if ($tagsEnabled && $this->tagIndexingPolicy->shouldNoindex($discussionTags)) {
             $properties->setMetaTag('robots', 'noindex, follow');
         }
+    }
+
+    /**
+     * Total community approval for a single post: flarum/likes likes plus
+     * fof/gamification upvotes (downvotes excluded), for whichever is enabled.
+     */
+    private function approvalCount(Post $post, bool $enableLikes, bool $enableGamification): int
+    {
+        $count = 0;
+
+        if ($enableLikes) {
+            $count += $post->likes()->count();
+        }
+
+        if ($enableGamification) {
+            // Positive gamification votes only (mirrors its `upvotes` relation).
+            $count += $post->votes()->where('value', '>', 0)->count();
+        }
+
+        return $count;
     }
 }

--- a/tests/integration/forum/DiscussionCommentsTest.php
+++ b/tests/integration/forum/DiscussionCommentsTest.php
@@ -1,0 +1,164 @@
+<?php
+
+/*
+ * This file is part of fof/seo.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Seo\Tests\integration\forum;
+
+use Carbon\Carbon;
+use FoF\Seo\Tests\integration\ForumHtmlTestCase;
+
+/**
+ * When "crawl all posts" is enabled, a discussion's replies are exposed as
+ * schema.org `Comment` nodes on the `DiscussionForumPosting`, each carrying a
+ * `LikeAction` upvote count. The count is sourced from flarum/likes or, when
+ * present, fof/gamification's votes — restoring the per-reply approval signal
+ * lost when the old QAPage-everywhere behaviour was removed (GH #130).
+ */
+class DiscussionCommentsTest extends ForumHtmlTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-seo');
+
+        $this->setting('forum_title', 'Example Forum');
+        $this->setting('seo_post_crawler', '1');
+    }
+
+    private function seedThread(): void
+    {
+        $this->prepareDatabase([
+            'users' => [
+                ['id' => 2, 'username' => 'alice', 'email' => 'a@example.com', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'is_email_confirmed' => 1],
+                ['id' => 3, 'username' => 'bob', 'email' => 'b@example.com', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'is_email_confirmed' => 1],
+            ],
+            'discussions' => [
+                ['id' => 1, 'title' => 'How do I bake bread', 'slug' => 'bake-bread', 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 3, 'created_at' => Carbon::now()],
+            ],
+            'posts' => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>The question.</p></t>', 'created_at' => Carbon::now()],
+                ['id' => 2, 'discussion_id' => 1, 'number' => 2, 'user_id' => 3, 'type' => 'comment', 'content' => '<t><p>The popular reply.</p></t>', 'created_at' => Carbon::now()],
+                ['id' => 3, 'discussion_id' => 1, 'number' => 3, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>Another reply.</p></t>', 'created_at' => Carbon::now()],
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function replies_are_not_exposed_when_post_crawler_is_disabled(): void
+    {
+        $this->setting('seo_post_crawler', '0');
+        $this->seedThread();
+
+        $entry = $this->findSchemaEntry($this->fetchForumHtml('/d/1-bake-bread'), 'DiscussionForumPosting');
+
+        $this->assertNotNull($entry);
+        $this->assertArrayNotHasKey('comment', $entry);
+    }
+
+    /**
+     * @test
+     */
+    public function replies_are_emitted_as_comment_nodes_when_crawler_enabled(): void
+    {
+        $this->extension('flarum-likes');
+        $this->seedThread();
+
+        $entry = $this->findSchemaEntry($this->fetchForumHtml('/d/1-bake-bread'), 'DiscussionForumPosting');
+
+        $comments = $entry['comment'] ?? null;
+        $this->assertIsArray($comments);
+        $this->assertCount(2, $comments, 'Expected both replies as Comment nodes (the first post is the posting itself).');
+
+        $first = $comments[0];
+        $this->assertSame('Comment', $first['@type'] ?? null);
+        $this->assertSame('Person', $first['author']['@type'] ?? null);
+        $this->assertSame('bob', $first['author']['name'] ?? null);
+        $this->assertStringContainsString('The popular reply.', $first['text'] ?? '');
+        $this->assertStringContainsString('/d/1-bake-bread', $first['url'] ?? '');
+    }
+
+    /**
+     * @test
+     */
+    public function comment_like_count_is_exposed_from_flarum_likes(): void
+    {
+        $this->extension('flarum-likes');
+        $this->seedThread();
+
+        // Two users like the first reply (post 2).
+        $this->database()->table('post_likes')->insert([
+            ['post_id' => 2, 'user_id' => 2],
+            ['post_id' => 2, 'user_id' => 3],
+        ]);
+
+        $entry = $this->findSchemaEntry($this->fetchForumHtml('/d/1-bake-bread'), 'DiscussionForumPosting');
+
+        $stat = $entry['comment'][0]['interactionStatistic'] ?? null;
+        $this->assertSame('InteractionCounter', $stat['@type'] ?? null);
+        $this->assertSame('https://schema.org/LikeAction', $stat['interactionType'] ?? null);
+        $this->assertSame(2, $stat['userInteractionCount'] ?? null);
+    }
+
+    /**
+     * With only fof/gamification enabled, the count comes from its votes and
+     * only positive votes count (downvotes are excluded).
+     *
+     * @test
+     */
+    public function comment_upvote_count_is_exposed_from_gamification_votes(): void
+    {
+        $this->extension('fof-gamification');
+        $this->seedThread();
+
+        // Post 2: two upvotes (+1) and one downvote (-1) => upvoteCount 2.
+        $this->database()->table('post_votes')->insert([
+            ['post_id' => 2, 'user_id' => 1, 'value' => 1],
+            ['post_id' => 2, 'user_id' => 3, 'value' => 1],
+            ['post_id' => 2, 'user_id' => 2, 'value' => -1],
+        ]);
+
+        $entry = $this->findSchemaEntry($this->fetchForumHtml('/d/1-bake-bread'), 'DiscussionForumPosting');
+
+        $stat = $entry['comment'][0]['interactionStatistic'] ?? null;
+        $this->assertSame('https://schema.org/LikeAction', $stat['interactionType'] ?? null);
+        $this->assertSame(2, $stat['userInteractionCount'] ?? null, 'Only positive gamification votes should count.');
+    }
+
+    /**
+     * When BOTH flarum/likes and fof/gamification are enabled, the counts are
+     * combined (they are independent signals stored in separate tables).
+     *
+     * @test
+     */
+    public function comment_count_combines_likes_and_gamification_when_both_enabled(): void
+    {
+        $this->extension('flarum-likes');
+        $this->extension('fof-gamification');
+        $this->seedThread();
+
+        // Post 2: one like + two upvotes (one downvote ignored) => 1 + 2 = 3.
+        $this->database()->table('post_likes')->insert([
+            ['post_id' => 2, 'user_id' => 1],
+        ]);
+        $this->database()->table('post_votes')->insert([
+            ['post_id' => 2, 'user_id' => 2, 'value' => 1],
+            ['post_id' => 2, 'user_id' => 3, 'value' => 1],
+            ['post_id' => 2, 'user_id' => 1, 'value' => -1],
+        ]);
+
+        $entry = $this->findSchemaEntry($this->fetchForumHtml('/d/1-bake-bread'), 'DiscussionForumPosting');
+
+        $stat = $entry['comment'][0]['interactionStatistic'] ?? null;
+        $this->assertSame(3, $stat['userInteractionCount'] ?? null, 'Likes and gamification upvotes should be summed.');
+    }
+}


### PR DESCRIPTION
Restores the per-reply community-approval signal reported lost in #130, using a standards-compliant structure.

## Background

In v2.0.7, a forum *without* best-answer emitted `QAPage` + `Answer` + `upvoteCount` for **every** discussion (a one-line inverted condition changed this in v2.0.8). That was schema misuse — `QAPage` is for genuine Q&A, not general threads — so we are not restoring it.

## What

When **post crawling** is enabled, each reply is now emitted as a schema.org `comment` (`Comment`) node on the `DiscussionForumPosting`, each carrying its own `interactionStatistic` (`LikeAction` `upvoteCount`). This is Google's recommended forum structure and is eligible for the Discussion-forum rich result.

The count **combines** signals for whichever is enabled:
- `flarum/likes` likes, and
- `fof/gamification` upvotes (downvotes excluded).

Replies are loaded with `withCount`/eager-loading to avoid N+1, and only when `seo_post_crawler` is on (so the default light path is unchanged). The first post's top-level `LikeAction` is now likes+gamification aware too.

## Tests

- crawler off → no `comment[]`
- crawler on → replies emitted as `Comment` nodes (author/text/url)
- likes only → per-comment `LikeAction` = like count
- gamification only → = upvotes (downvotes excluded)
- both enabled → counts summed

Also live-tested on a forum running fof/gamification: upvoted replies surface `LikeAction` counts matching their vote totals.

Adds `fof/gamification` as a dev dependency and registers its `extend.php` with PHPStan so its vote relations are recognised.

Closes #130