### PR TITLE
[2.x] fix: emit Open Graph article dates as property tags, add og:locale and og:image:alt

### DIFF
--- a/src/Listeners/PageListener.php
+++ b/src/Listeners/PageListener.php
@@ -164,6 +164,24 @@ class PageListener
             new PreparingPageMeta(new SeoProperties($this), $this->flarumDocument, $serverRequest)
         );
 
+        // Expose the resolved document language as og:locale (mirrors schema.org
+        // inLanguage), unless a driver/listener already set one explicitly.
+        $documentLanguage = $this->schemaArray['inLanguage'] ?? $locale;
+        if ($documentLanguage !== null && !isset($this->metaProperty['og:locale'])) {
+            $this->setMetaPropertyTag('og:locale', $this->normaliseLocale($documentLanguage));
+        }
+
+        // Describe the social image for preview cards / accessibility, unless set
+        // explicitly. Uses the page's og:title, falling back to the forum name.
+        if (isset($this->metaProperty['og:image']) && !isset($this->metaProperty['og:image:alt'])) {
+            $imageAlt = $this->metaProperty['og:title'] ?? $this->settings->get('forum_title');
+
+            if ($imageAlt !== null && $imageAlt !== '') {
+                $this->setMetaPropertyTag('og:image:alt', $imageAlt);
+                $this->setMetaTag('twitter:image:alt', $imageAlt);
+            }
+        }
+
         // Write meta property tags
         foreach ($this->metaProperty as $name => $content) {
             $this->flarumDocument->head[] = '<meta property="'.e($name).'" content="'.e($content).'">';
@@ -308,6 +326,17 @@ class PageListener
     }
 
     /**
+     * Normalise a Flarum locale (e.g. "en", "pt-br") to the Open Graph
+     * "language_TERRITORY" form (e.g. "en", "pt_BR").
+     */
+    private function normaliseLocale(string $locale): string
+    {
+        $parts = preg_split('/[-_]/', $locale, 2);
+
+        return $parts[0].(isset($parts[1]) ? '_'.strtoupper($parts[1]) : '');
+    }
+
+    /**
      * Set title.
      */
     public function setTitle(string $title, bool $headline = false): self
@@ -405,7 +434,8 @@ class PageListener
             : (new \DateTime($published))->format('c');
 
         $this
-            ->setMetaTag('article:published_time', $date)
+            // Open Graph article dates are `property` tags, not `name` tags.
+            ->setMetaPropertyTag('article:published_time', $date)
             ->setSchemaJson('datePublished', $date);
 
         return $this;
@@ -422,7 +452,8 @@ class PageListener
             : (new \DateTime($updated))->format('c');
 
         $this
-            ->setMetaTag('article:updated_time', $date)
+            // Open Graph uses `article:modified_time` (a `property` tag).
+            ->setMetaPropertyTag('article:modified_time', $date)
             ->setSchemaJson('dateModified', $date);
 
         return $this;

--- a/src/Listeners/PageListener.php
+++ b/src/Listeners/PageListener.php
@@ -164,6 +164,10 @@ class PageListener
             new PreparingPageMeta(new SeoProperties($this), $this->flarumDocument, $serverRequest)
         );
 
+        // Open Graph article dates only belong on article-type pages; emit them
+        // from the recorded schema.org dates when this page is an article.
+        $this->emitArticleDates();
+
         // Expose the resolved document language as og:locale (mirrors schema.org
         // inLanguage), unless a driver/listener already set one explicitly.
         $documentLanguage = $this->schemaArray['inLanguage'] ?? $locale;
@@ -326,6 +330,26 @@ class PageListener
     }
 
     /**
+     * Emit the Open Graph article:published_time / article:modified_time tags
+     * from the recorded schema.org dates, but only when the page is an article.
+     * On other page types (tag listings, profiles, …) these tags don't apply.
+     */
+    private function emitArticleDates(): void
+    {
+        if (($this->metaProperty['og:type'] ?? null) !== 'article') {
+            return;
+        }
+
+        if (isset($this->schemaArray['datePublished'])) {
+            $this->setMetaPropertyTag('article:published_time', $this->schemaArray['datePublished']);
+        }
+
+        if (isset($this->schemaArray['dateModified'])) {
+            $this->setMetaPropertyTag('article:modified_time', $this->schemaArray['dateModified']);
+        }
+    }
+
+    /**
      * Normalise a Flarum locale (e.g. "en", "pt-br") to the Open Graph
      * "language_TERRITORY" form (e.g. "en", "pt_BR").
      */
@@ -433,10 +457,10 @@ class PageListener
             ? $published->format('c')
             : (new \DateTime($published))->format('c');
 
-        $this
-            // Open Graph article dates are `property` tags, not `name` tags.
-            ->setMetaPropertyTag('article:published_time', $date)
-            ->setSchemaJson('datePublished', $date);
+        // Record the date on the schema.org entity. The matching Open Graph
+        // article:published_time tag is emitted in finish(), but only for
+        // article-type pages (see emitArticleDates()).
+        $this->setSchemaJson('datePublished', $date);
 
         return $this;
     }
@@ -451,10 +475,9 @@ class PageListener
             ? $updated->format('c')
             : (new \DateTime($updated))->format('c');
 
-        $this
-            // Open Graph uses `article:modified_time` (a `property` tag).
-            ->setMetaPropertyTag('article:modified_time', $date)
-            ->setSchemaJson('dateModified', $date);
+        // As with datePublished, the og:article:modified_time tag is emitted in
+        // finish() only when og:type is "article".
+        $this->setSchemaJson('dateModified', $date);
 
         return $this;
     }

--- a/tests/integration/forum/DiscussionPageTest.php
+++ b/tests/integration/forum/DiscussionPageTest.php
@@ -207,18 +207,36 @@ class DiscussionPageTest extends ForumHtmlTestCase
     }
 
     #[Test]
-    public function discussion_page_emits_article_published_time(): void
+    public function discussion_page_emits_article_times_as_open_graph_properties(): void
     {
         $publishedAt = Carbon::parse('2025-06-01 12:34:56');
+        $modifiedAt = Carbon::parse('2025-06-02 08:00:00');
 
-        $this->seedDiscussion(title: 'How to bake bread', slug: 'bake-bread', createdAt: $publishedAt);
+        $this->seedDiscussion(
+            title: 'How to bake bread',
+            slug: 'bake-bread',
+            createdAt: $publishedAt,
+            metaOverrides: ['updated_at' => $modifiedAt],
+        );
 
         $html = $this->fetchForumHtml('/d/1-bake-bread');
 
+        // Open Graph article dates must use `property` (not `name`), or OG
+        // consumers (Facebook, etc.) won't read them — and the modified date is
+        // `article:modified_time`, not the non-standard `article:updated_time`.
         $this->assertSame(
             $publishedAt->format('c'),
-            $this->findMetaByName($html, 'article:published_time')
+            $this->findMetaByProperty($html, 'article:published_time')
         );
+        $this->assertSame(
+            $modifiedAt->format('c'),
+            $this->findMetaByProperty($html, 'article:modified_time')
+        );
+
+        // The previous, incorrect forms must be gone.
+        $this->assertNull($this->findMetaByName($html, 'article:published_time'));
+        $this->assertNull($this->findMetaByName($html, 'article:updated_time'));
+        $this->assertNull($this->findMetaByProperty($html, 'article:updated_time'));
     }
 
     /**

--- a/tests/integration/forum/IndexPageTest.php
+++ b/tests/integration/forum/IndexPageTest.php
@@ -69,6 +69,28 @@ class IndexPageTest extends ForumHtmlTestCase
     }
 
     #[Test]
+    public function index_page_emits_og_locale_from_the_document_language(): void
+    {
+        $html = $this->fetchForumHtml('/');
+
+        // Default test locale is English; og:locale uses the language_TERRITORY form.
+        $this->assertSame('en', $this->findMetaByProperty($html, 'og:locale'));
+    }
+
+    #[Test]
+    public function og_image_carries_alt_text_describing_the_page(): void
+    {
+        // og:image is emitted once an image source (here, the logo) is configured.
+        $this->setting('logo_path', 'logo.png');
+
+        $html = $this->fetchForumHtml('/');
+
+        $this->assertNotNull($this->findMetaByProperty($html, 'og:image'), 'precondition: og:image present');
+        $this->assertSame('Example Forum', $this->findMetaByProperty($html, 'og:image:alt'));
+        $this->assertSame('Example Forum', $this->findMetaByName($html, 'twitter:image:alt'));
+    }
+
+    #[Test]
     public function twitter_card_type_respects_the_seo_twitter_card_size_setting(): void
     {
         $this->setting('seo_twitter_card_size', 'summary');

--- a/tests/integration/forum/TagPageTest.php
+++ b/tests/integration/forum/TagPageTest.php
@@ -58,6 +58,20 @@ class TagPageTest extends ForumHtmlTestCase
     }
 
     #[Test]
+    public function tag_page_is_website_type_without_article_date_tags(): void
+    {
+        $html = $this->fetchForumHtml('/t/announcements');
+
+        // A tag listing is og:type "website" (the listing semantics live in the
+        // schema.org CollectionPage); the article:* date tags belong to
+        // article-type pages and must not leak onto it.
+        $this->assertSame('website', $this->findMetaByProperty($html, 'og:type'));
+        $this->assertNull($this->findMetaByProperty($html, 'article:published_time'));
+        $this->assertNull($this->findMetaByProperty($html, 'article:modified_time'));
+        $this->assertNull($this->findMetaByName($html, 'article:published_time'));
+    }
+
+    #[Test]
     public function tag_page_emits_og_title_from_tag_name(): void
     {
         $html = $this->fetchForumHtml('/t/announcements');


### PR DESCRIPTION
Follow-up to the 2.0 migration. A crawler-perspective audit of the rendered `<head>` surfaced a few Open Graph issues:

- **`article:published_time` / `article:updated_time` were emitted as `name=` meta tags**, and `article:updated_time` isn't the OG-spec name. Open Graph consumers (Facebook, etc.) only read `property=` tags, so the publish/modify dates were invisible to them — they were correct in the JSON-LD (`datePublished`/`dateModified`), so search engines were unaffected. Now emitted as `property="article:published_time"` and `property="article:modified_time"`.
- **No `og:locale`** — now derived from the resolved document language (mirrors the schema.org `inLanguage` value), normalised to the `language_TERRITORY` form (e.g. `en`, `pt_BR`).
- **No alt text on the social image** — added `og:image:alt` / `twitter:image:alt`, derived from the page's `og:title` (falling back to the forum name).

`og:image:width`/`height` were intentionally left out: emitting accurate dimensions would require fetching/measuring arbitrary (often remote) images at render time, which isn't safe on a page request.