### PR TITLE
[2.x] docs: correct Open Graph article tag references

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ SEO tags are generated for the following pages:
 Methods used:
 
 - HTML meta tags (`application-name`, `description`, `keywords`, `language`)
-- Open Graph tags (`og:type`, `og:title`, `og:description`, `og:url`, `article:published_time`, `article:updated_time`)
+- Open Graph tags (`og:type`, `og:title`, `og:description`, `og:url`, `og:image`, `og:locale`, and `article:published_time` / `article:modified_time` on article pages)
 - Twitter cards
 - `inLanguage` on every page
 - Schema.org structured data:

--- a/docs/developers/seoproperties.md
+++ b/docs/developers/seoproperties.md
@@ -99,9 +99,13 @@ Sets `og:image`, `twitter:image` and the JSON-LD `image`.
 ## Published / updated timestamps
 
 ```php
-$properties->setPublishedOn('2020-08-22 14:14:00'); // article:published_time + datePublished
-$properties->setUpdatedOn('2020-08-25 18:55:00');   // article:updated_time + dateModified
+$properties->setPublishedOn('2020-08-22 14:14:00'); // schema.org datePublished
+$properties->setUpdatedOn('2020-08-25 18:55:00');   // schema.org dateModified
 ```
+
+These record the dates on the schema.org entity. The matching Open Graph
+`article:published_time` / `article:modified_time` (`property`) tags are emitted
+automatically — but only when the page's `og:type` is `article`.
 
 ## Lower-level helpers
 


### PR DESCRIPTION
Follow-up to #138, which renamed and gated the Open Graph article date tags. Two doc references were left stale:

- **README** "Methods used" listed `article:updated_time` — now `article:modified_time` (and noted it's only emitted on article pages); also added `og:image` / `og:locale` to reflect what's emitted.
- **docs/developers/seoproperties.md** documented `setPublishedOn`/`setUpdatedOn` as emitting `article:published_time`/`article:updated_time` directly. They now record the schema.org `datePublished`/`dateModified`, and the matching OG `article:*` (`property`) tags are emitted automatically only when `og:type` is `article` — which is what third-party page-driver authors need to know.

Docs only.