### PR TITLE
[2.x] fix: emit datePublished on comment/posting nodes and cap crawled replies

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -46,6 +46,12 @@ return [
 
     new Extend\Locales(__DIR__.'/locale'),
 
+    // Cap how many replies are emitted as schema.org Comment nodes when the
+    // post crawler is enabled. Rendering each reply is the dominant cost on
+    // page load, so bound it; Google only needs the comments shown on the page.
+    (new Extend\Settings())
+      ->default('seo_post_crawler_limit', 100),
+
     (new Extend\Formatter())
       ->render(FormatLinks::class)
       ->configure(ConfigureLinks::class),

--- a/src/Page/DiscussionPage.php
+++ b/src/Page/DiscussionPage.php
@@ -130,6 +130,16 @@ class DiscussionPage implements PageDriverInterface
         // Schema.org DiscussionForumPosting enrichment (Google forum guidelines).
         $properties->setSchemaJson('headline', $seoMeta->title ?? $discussion->title);
 
+        // `datePublished` is a required property for DiscussionForumPosting.
+        if ($discussion->created_at !== null) {
+            $properties->setSchemaJson('datePublished', $discussion->created_at->toIso8601String());
+        }
+
+        // Surface the last activity as `dateModified` (recommended).
+        if ($discussion->last_posted_at !== null) {
+            $properties->setSchemaJson('dateModified', $discussion->last_posted_at->toIso8601String());
+        }
+
         $replyCount = max(0, $discussion->comment_count - 1);
         $properties->setSchemaJson('commentCount', $replyCount);
 
@@ -153,8 +163,10 @@ class DiscussionPage implements PageDriverInterface
         $firstPost = $discussion->firstPost;
 
         if ($firstPost instanceof CommentPost) {
-            // Full post text for the `text` property.
-            $text = trim(strip_tags($firstPost->formatContent()));
+            // Full post text for the `text` property. Render to HTML first so
+            // render-time transforms (mentions -> display names, links) resolve,
+            // then decode entities and strip tags for clean plain text.
+            $text = trim(html_entity_decode(strip_tags($firstPost->formatContent()), ENT_QUOTES | ENT_HTML5));
 
             if ($text !== '') {
                 $properties->setSchemaJson('text', $text);
@@ -188,22 +200,37 @@ class DiscussionPage implements PageDriverInterface
                 $countRelations[] = 'upvotes';
             }
 
-            /** @var Collection<int, Post> $replies */
-            $replies = $discussion->posts()
+            // Cap the number of replies rendered into the comment[] block.
+            // Rendering each reply (formatContent) is the dominant page-load
+            // cost, so bound it; a value <= 0 disables the cap entirely.
+            $limit = (int) $this->settingsRepositoryInterface->get('seo_post_crawler_limit', 100);
+
+            $query = $discussion->posts()
                 ->where('number', '>', 1)
                 ->where('type', 'comment')
                 ->where('is_private', false)
                 ->with('user')
                 ->withCount($countRelations)
-                ->orderBy('number')
-                ->get();
+                ->orderBy('number');
 
-            $comments = $replies->map(function (Post $post) use ($discussion, $enableLikes, $enableGamification) {
+            if ($limit > 0) {
+                $query->limit($limit);
+            }
+
+            /** @var Collection<int, Post> $replies */
+            $replies = $query->get();
+
+            $comments = $replies->filter(fn (Post $post) => $post instanceof CommentPost)->map(function (CommentPost $post) use ($discussion, $enableLikes, $enableGamification) {
                 $comment = [
-                    '@type'       => 'Comment',
-                    'text'        => trim(strip_tags($post->content)),
-                    'dateCreated' => $post->created_at->toIso8601String(),
-                    'url'         => $this->urlGenerator->to('forum')->route('discussion', ['id' => $discussion->id.'-'.$discussion->slug, 'near' => $post->number]),
+                    '@type'         => 'Comment',
+                    // Render to HTML so mentions/links resolve, then decode
+                    // entities and strip tags for clean plain text.
+                    'text'          => trim(html_entity_decode(strip_tags($post->formatContent()), ENT_QUOTES | ENT_HTML5)),
+                    // Google requires `datePublished` on Comment nodes; keep
+                    // `dateCreated` too for schema.org completeness.
+                    'datePublished' => $post->created_at->toIso8601String(),
+                    'dateCreated'   => $post->created_at->toIso8601String(),
+                    'url'           => $this->urlGenerator->to('forum')->route('discussion', ['id' => $discussion->id.'-'.$discussion->slug, 'near' => $post->number]),
                 ];
 
                 // Author, when the post still has one (skip for deleted users).
@@ -234,7 +261,7 @@ class DiscussionPage implements PageDriverInterface
                 }
 
                 return $comment;
-            })->toArray();
+            })->values()->toArray();
 
             if (count($comments) > 0) {
                 $properties->setSchemaJson('comment', $comments);

--- a/tests/integration/forum/DiscussionCommentsTest.php
+++ b/tests/integration/forum/DiscussionCommentsTest.php
@@ -85,6 +85,67 @@ class DiscussionCommentsTest extends ForumHtmlTestCase
         $this->assertSame('bob', $first['author']['name'] ?? null);
         $this->assertStringContainsString('The popular reply.', $first['text'] ?? '');
         $this->assertStringContainsString('/d/1-bake-bread', $first['url'] ?? '');
+        // Google requires `datePublished` on Comment nodes (ISO 8601).
+        $this->assertNotEmpty($first['datePublished'] ?? null);
+        $this->assertSame(Carbon::parse($first['datePublished'])->toIso8601String(), $first['datePublished']);
+    }
+
+    /**
+     * The number of emitted Comment nodes is capped by the
+     * `seo_post_crawler_limit` setting, keeping the lowest-numbered replies
+     * (the order they appear on the page). Rendering every reply is the
+     * dominant page-load cost, so the cap bounds it.
+     */
+    #[Test]
+    public function comment_count_is_capped_by_the_limit_setting(): void
+    {
+        // The seeded thread has two replies; a limit of 1 should emit only the
+        // first (lowest-numbered) reply, in the order it appears on the page.
+        $this->setting('seo_post_crawler_limit', '1');
+        $this->seedThread();
+
+        $entry = $this->findSchemaEntry($this->fetchForumHtml('/d/1-bake-bread'), 'DiscussionForumPosting');
+
+        $comments = $entry['comment'] ?? null;
+        $this->assertIsArray($comments);
+        $this->assertCount(1, $comments);
+        $this->assertStringContainsString('The popular reply.', $comments[0]['text'] ?? '');
+    }
+
+    /**
+     * Comment `text` must be plain text rendered from the stored markup — not
+     * the raw TextFormatter representation. A reply containing bold, a link and
+     * an HTML entity should come through with the formatting stripped, the link
+     * reduced to its visible label, and the entity decoded.
+     */
+    #[Test]
+    public function comment_text_is_rendered_to_plain_text(): void
+    {
+        $this->prepareDatabase([
+            User::class => [
+                ['id' => 2, 'username' => 'alice', 'email' => 'a@example.com', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'is_email_confirmed' => 1],
+                ['id' => 3, 'username' => 'bob', 'email' => 'b@example.com', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'is_email_confirmed' => 1],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'How do I bake bread', 'slug' => 'bake-bread', 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 2, 'created_at' => Carbon::now()],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>The question.</p></t>', 'created_at' => Carbon::now()],
+                ['id' => 2, 'discussion_id' => 1, 'number' => 2, 'user_id' => 3, 'type' => 'comment', 'content' => '<r><p><STRONG>Bold</STRONG> and Tom &amp; Jerry visit <URL url="https://example.com">example.com</URL></p></r>', 'created_at' => Carbon::now()],
+            ],
+        ]);
+
+        $entry = $this->findSchemaEntry($this->fetchForumHtml('/d/1-bake-bread'), 'DiscussionForumPosting');
+
+        $text = $entry['comment'][0]['text'] ?? '';
+
+        // Plain text: markup stripped, link as its label, entity decoded.
+        $this->assertSame('Bold and Tom & Jerry visit example.com', $text);
+        // No raw TextFormatter markup or undecoded entities leaked through.
+        $this->assertStringNotContainsString('STRONG', $text);
+        $this->assertStringNotContainsString('URL', $text);
+        $this->assertStringNotContainsString('https://example.com', $text);
+        $this->assertStringNotContainsString('&amp;', $text);
     }
 
     #[Test]


### PR DESCRIPTION
> **Target branch: `2.x`** (Flarum 2.x). This is 2.x-only work.

## What

Improves the `DiscussionForumPosting` structured data to satisfy Google's discussion-forum guidelines and bounds its cost on page load.

- **Adds the required `datePublished` to each `Comment` node.** Previously only `dateCreated` was set; Google requires `datePublished` on comments, which Search Console reports as a non-critical "Missing field 'comment'" issue once post crawling is enabled. `dateCreated` is kept for schema.org completeness.
- **Sets `datePublished` (required) and `dateModified` (recommended) on the top-level posting** from the discussion's own `created_at` / `last_posted_at`, rather than relying on the generic SeoMeta flow.
- **Renders comment and first-post `text` to plain text** via `formatContent()` (then decode entities + strip tags) so mentions resolve to display names and HTML entities decode, instead of leaking raw TextFormatter markup or unparsed source.
- **Caps the number of replies emitted as `Comment` nodes** behind a new `seo_post_crawler_limit` setting (default `100`). Rendering each reply is the dominant page-load cost when the post crawler is on; the cap bounds the query, the render passes, and the JSON-LD payload size. A value `<= 0` disables the cap.

## Out of scope

#140 ("Missing field 'author' (in 'comment')") was reported against 1.x (v3.0.1). That deleted-user `author` bug needs fixing on both branches and is tracked separately — it is **not** addressed by this PR.