### PR TITLE
[1.x] fix: always emit author on comment/answer nodes for deleted users

### DIFF
--- a/src/Page/DiscussionBestAnswerPage.php
+++ b/src/Page/DiscussionBestAnswerPage.php
@@ -28,6 +28,7 @@ use FoF\Seo\TagIndexingPolicy;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DiscussionBestAnswerPage implements PageDriverInterface
 {
@@ -42,8 +43,32 @@ class DiscussionBestAnswerPage implements PageDriverInterface
         Dispatcher $events,
         protected readonly SlugManager $slugManager,
         protected readonly TagIndexingPolicy $tagIndexingPolicy,
+        protected readonly TranslatorInterface $translator,
     ) {
         $this->events = $events;
+    }
+
+    /**
+     * Build a schema.org Person for a question/answer author. `author` is a
+     * required field, so a deleted user falls back to the localized "[deleted]"
+     * display name with no profile url rather than `name: null` (GH #140).
+     *
+     * @return array<string, string>
+     */
+    private function authorSchema(?User $user): array
+    {
+        if ($user === null) {
+            return [
+                '@type' => 'Person',
+                'name'  => $this->translator->trans('core.lib.username.deleted_text'),
+            ];
+        }
+
+        return [
+            '@type' => 'Person',
+            'name'  => $user->getDisplayNameAttribute(),
+            'url'   => $this->urlGenerator->to('forum')->route('user', ['username' => $this->slugManager->forResource(User::class)->toSlug($user)]),
+        ];
     }
 
     public function extensionDependencies(): array
@@ -146,11 +171,7 @@ class DiscussionBestAnswerPage implements PageDriverInterface
             'name'        => $seoMeta->title,
             'text'        => $firstPost !== null ? strip_tags($firstPost->content) : '',
             'dateCreated' => $seoMeta->created_at,
-            'author'      => [
-                '@type' => 'Person',
-                'name'  => $discussion->user?->getDisplayNameAttribute(),
-                'url'   => $discussion->user ? $this->urlGenerator->to('forum')->route('user', ['username' => $this->slugManager->forResource(User::class)->toSlug($discussion->user)]) : null,
-            ],
+            'author'      => $this->authorSchema($discussion->user),
             'answerCount' => $discussion->comment_count - 1,
         ];
 
@@ -198,11 +219,7 @@ class DiscussionBestAnswerPage implements PageDriverInterface
                 'text'        => strip_tags($post->content),
                 'dateCreated' => $post->created_at->toIso8601String(),
                 'url'         => $this->urlGenerator->to('forum')->route('discussion', ['id' => $discussion->id.'-'.$discussion->slug, 'near' => $post->number]),
-                'author'      => [
-                    '@type' => 'Person',
-                    'name'  => $post->user ? $post->user->display_name : null,
-                    'url'   => $post->user ? $this->urlGenerator->to('forum')->route('user', ['username' => $this->slugManager->forResource(User::class)->toSlug($post->user)]) : null,
-                ],
+                'author'      => $this->authorSchema($post->user),
             ];
 
             // Upvote/like count

--- a/src/Page/DiscussionPage.php
+++ b/src/Page/DiscussionPage.php
@@ -29,6 +29,7 @@ use FoF\Seo\TagIndexingPolicy;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DiscussionPage implements PageDriverInterface
 {
@@ -43,8 +44,33 @@ class DiscussionPage implements PageDriverInterface
         Dispatcher $events,
         protected readonly SlugManager $slugManager,
         protected readonly TagIndexingPolicy $tagIndexingPolicy,
+        protected readonly TranslatorInterface $translator,
     ) {
         $this->events = $events;
+    }
+
+    /**
+     * Build a schema.org Person for a post/discussion author. `author` is a
+     * required field on DiscussionForumPosting and on each Comment (GH #140),
+     * so a deleted user falls back to the localized "[deleted]" display name
+     * with no profile url rather than being omitted.
+     *
+     * @return array<string, string>
+     */
+    private function authorSchema(?User $user): array
+    {
+        if ($user === null) {
+            return [
+                '@type' => 'Person',
+                'name'  => $this->translator->trans('core.lib.username.deleted_text'),
+            ];
+        }
+
+        return [
+            '@type' => 'Person',
+            'name'  => $user->getDisplayNameAttribute(),
+            'url'   => $this->urlGenerator->to('forum')->route('user', ['username' => $this->slugManager->forResource(User::class)->toSlug($user)]),
+        ];
     }
 
     public function extensionDependencies(): array
@@ -202,14 +228,9 @@ class DiscussionPage implements PageDriverInterface
                     'url'         => $this->urlGenerator->to('forum')->route('discussion', ['id' => $discussion->id.'-'.$discussion->slug, 'near' => $post->number]),
                 ];
 
-                // Author, when the post still has one (skip for deleted users).
-                if ($post->user !== null) {
-                    $comment['author'] = [
-                        '@type' => 'Person',
-                        'name'  => $post->user->getAttribute('display_name'),
-                        'url'   => $this->urlGenerator->to('forum')->route('user', ['username' => $this->slugManager->forResource(User::class)->toSlug($post->user)]),
-                    ];
-                }
+                // `author` is required on a Comment; deleted users fall back to
+                // a "[deleted]" Person rather than being omitted (GH #140).
+                $comment['author'] = $this->authorSchema($post->user);
 
                 if ($enableLikes || $enableGamification) {
                     $count = 0;
@@ -237,22 +258,9 @@ class DiscussionPage implements PageDriverInterface
             }
         }
 
-        try {
-            // Add author to the page meta data
-            $user = $discussion->user;
-
-            // Set author data if found
-            if ($user !== null) {
-                // author: https://schema.org/author typeof: https://schema.org/Person
-                $properties->setSchemaJson('author', [
-                    '@type' => 'Person',
-                    'name'  => $user->getDisplayNameAttribute(),
-                    'url'   => $this->urlGenerator->to('forum')->route('user', ['username' => $this->slugManager->forResource(User::class)->toSlug($user)]),
-                ]);
-            }
-        } catch (\Exception $e) {
-            // User does not exists anymore
-        }
+        // author: https://schema.org/author typeof: https://schema.org/Person.
+        // Required field, so a deleted author falls back to "[deleted]" (#140).
+        $properties->setSchemaJson('author', $this->authorSchema($discussion->user));
 
         // Generate a breadcrum if discussion has tags
         if ($tagsEnabled && $discussionTags->count() >= 1) {

--- a/tests/integration/forum/BestAnswerPageTest.php
+++ b/tests/integration/forum/BestAnswerPageTest.php
@@ -171,6 +171,47 @@ class BestAnswerPageTest extends ForumHtmlTestCase
     }
 
     /**
+     * `author` is required on a schema.org Answer/Question (GH #140). When an
+     * answer's author has been deleted, the QAPage must still emit an `author`
+     * Person with the localized "[deleted]" name and no null fields, rather
+     * than `name: null`.
+     *
+     * @test
+     */
+    public function answer_by_deleted_user_still_has_a_named_author(): void
+    {
+        $this->setting('seo_post_crawler', '1');
+
+        $now = Carbon::now();
+
+        $this->prepareDatabase([
+            'tags' => [
+                ['id' => self::QNA_TAG_ID, 'name' => 'Questions', 'slug' => 'questions', 'description' => null, 'color' => '#000', 'position' => 0, 'is_restricted' => false, 'is_hidden' => false, 'is_qna' => true],
+            ],
+            'discussions' => [
+                ['id' => 1, 'title' => 'How do I bake bread?', 'slug' => 'how-do-i-bake-bread', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 2, 'best_answer_post_id' => 2, 'created_at' => $now, 'last_posted_at' => $now],
+            ],
+            'posts' => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>How do I bake bread?</p></t>', 'created_at' => $now],
+                // Accepted answer by a user that no longer exists (no row id 99).
+                ['id' => 2, 'discussion_id' => 1, 'number' => 2, 'user_id' => 99, 'type' => 'comment', 'content' => '<t><p>Use flour and water.</p></t>', 'created_at' => $now],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => self::QNA_TAG_ID],
+            ],
+        ]);
+
+        $accepted = $this->findSchemaEntry($this->fetchForumHtml('/d/1-how-do-i-bake-bread'), 'QAPage')['mainEntity']['acceptedAnswer'] ?? [];
+
+        $author = $accepted['author'] ?? null;
+        $this->assertIsArray($author);
+        $this->assertSame('Person', $author['@type'] ?? null);
+        $this->assertSame('[deleted]', $author['name'] ?? null);
+        // No profile exists for a deleted user, so no url should be emitted.
+        $this->assertArrayNotHasKey('url', $author);
+    }
+
+    /**
      * The optional flarum/likes integration: when it's enabled, an answer's
      * `upvoteCount` reflects its like count.
      *

--- a/tests/integration/forum/DiscussionCommentsTest.php
+++ b/tests/integration/forum/DiscussionCommentsTest.php
@@ -88,6 +88,41 @@ class DiscussionCommentsTest extends ForumHtmlTestCase
     }
 
     /**
+     * `author` is a required nested field on a schema.org Comment (GH #140).
+     * A reply whose author has been deleted must still emit an `author` Person
+     * with the localized "[deleted]" display name (and no profile url), rather
+     * than omitting the field entirely.
+     *
+     * @test
+     */
+    public function comment_by_deleted_user_still_has_an_author(): void
+    {
+        $this->prepareDatabase([
+            'users' => [
+                ['id' => 2, 'username' => 'alice', 'email' => 'a@example.com', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'is_email_confirmed' => 1],
+            ],
+            'discussions' => [
+                ['id' => 1, 'title' => 'How do I bake bread', 'slug' => 'bake-bread', 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 2, 'created_at' => Carbon::now()],
+            ],
+            'posts' => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>The question.</p></t>', 'created_at' => Carbon::now()],
+                // Reply by a user that no longer exists (user_id 99 has no row).
+                ['id' => 2, 'discussion_id' => 1, 'number' => 2, 'user_id' => 99, 'type' => 'comment', 'content' => '<t><p>Orphaned reply.</p></t>', 'created_at' => Carbon::now()],
+            ],
+        ]);
+
+        $entry = $this->findSchemaEntry($this->fetchForumHtml('/d/1-bake-bread'), 'DiscussionForumPosting');
+
+        $comment = $entry['comment'][0] ?? null;
+        $this->assertIsArray($comment);
+        // The author field must be present and a Person with a name.
+        $this->assertSame('Person', $comment['author']['@type'] ?? null);
+        $this->assertSame('[deleted]', $comment['author']['name'] ?? null);
+        // A deleted user has no profile, so no url should be emitted.
+        $this->assertArrayNotHasKey('url', $comment['author']);
+    }
+
+    /**
      * @test
      */
     public function comment_like_count_is_exposed_from_flarum_likes(): void


### PR DESCRIPTION
1.x port of #142. Closes #140.

## What

Google requires `author` as a nested field on schema.org `Comment` and `Answer`/`Question` nodes. Replies and answers whose author has been **deleted** were handled inconsistently and incorrectly:

- `DiscussionForumPosting` comment nodes (and the top-level posting) **omitted `author` entirely** when the user was gone.
- `QAPage` question/answer nodes emitted `author` with **`name: null`** (and `url: null`).

Both produce Search Console's "Missing field 'author' (in 'comment')" report.

## Fix

A shared `authorSchema()` helper in each page driver always returns a valid `Person`:

- existing user → display name + profile `url`;
- deleted user → the localized `core.lib.username.deleted_text` (`[deleted]`) name and **no** `url`.

Applied to the top-level posting author, each comment, the QAPage question, and each answer. Also removes a defensive `try/catch` around the top-level author that was dead code (`$discussion->user` returns `null` for a deleted user rather than throwing).

## Tests

- `DiscussionCommentsTest::comment_by_deleted_user_still_has_an_author` — a reply by a deleted user emits an `author` Person named `[deleted]` with no `url`.
- `BestAnswerPageTest::answer_by_deleted_user_still_has_a_named_author` — an accepted answer by a deleted user emits an `author` Person named `[deleted]` (not `name: null`) with no `url`.

Integration suite for the affected drivers and PHPStan both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)