### PR TITLE
[2.x] feat: emit QAPage for answered Q&A discussions even with the crawler off

### DIFF
--- a/src/Page/DiscussionBestAnswerPage.php
+++ b/src/Page/DiscussionBestAnswerPage.php
@@ -87,11 +87,6 @@ class DiscussionBestAnswerPage implements PageDriverInterface
         ServerRequestInterface $request,
         SeoProperties $properties
     ): void {
-        // Simple discussion tags is set up
-        if ($this->settingsRepositoryInterface->get('seo_post_crawler', 0) == 0) {
-            return;
-        }
-
         // Get discussion ID from params
         // Cast to int to extract the numeric id from the `{id}-{slug}` route
         // param so the lookup works on all databases (SQLite won't coerce it).
@@ -119,6 +114,17 @@ class DiscussionBestAnswerPage implements PageDriverInterface
         // Not a Q&A discussion — DiscussionPage already emitted DiscussionForumPosting.
         // A child of a Q&A tag counts as Q&A too (flarum-tags nests one level).
         if (!$discussionTags->contains(fn (Tag $tag) => (bool) $tag->is_qna || (bool) $tag->parent?->is_qna)) {
+            return;
+        }
+
+        $crawlerEnabled = $this->settingsRepositoryInterface->get('seo_post_crawler', 0) == 1;
+
+        // With the post crawler on we emit the full QAPage (every answer). With
+        // it off we still emit a QAPage — but only when an accepted answer
+        // exists, and only that answer, which is cheap because the best-answer
+        // post is loaded on its own. A Q&A discussion with no accepted answer
+        // falls through to DiscussionPage's DiscussionForumPosting.
+        if (!$crawlerEnabled && $discussion->best_answer_post_id === null) {
             return;
         }
 
@@ -197,7 +203,7 @@ class DiscussionBestAnswerPage implements PageDriverInterface
         // Only add suggested answers property if there are posts
         $mainEntity['suggestedAnswer'] = [];
 
-        // Get all public comments for this discussion
+        // Get the answer posts for this discussion.
         // Eager-load the author (and likes, when the extension is enabled)
         // relations referenced in the loop below to avoid an N+1 per answer post.
         $with = ['user'];
@@ -205,11 +211,18 @@ class DiscussionBestAnswerPage implements PageDriverInterface
             $with[] = 'likes';
         }
 
-        /** @var Collection<int, Post> $posts */
-        $posts = $discussion->posts()
+        $postsQuery = $discussion->posts()
             ->where('number', '>', '1')
-            ->with($with)
-            ->get();
+            ->with($with);
+
+        // With the crawler off we only surface the accepted answer, so load
+        // just that post rather than the whole thread.
+        if (!$crawlerEnabled) {
+            $postsQuery->where('id', $bestAnswerId);
+        }
+
+        /** @var Collection<int, Post> $posts */
+        $posts = $postsQuery->get();
 
         foreach ($posts as $post) {
             /** @var Post $post */

--- a/src/Page/DiscussionPage.php
+++ b/src/Page/DiscussionPage.php
@@ -110,16 +110,20 @@ class DiscussionPage implements PageDriverInterface
         /** @var Collection<int, Tag> $discussionTags */
         $discussionTags = $discussion->tags;
 
-        // Defer to DiscussionBestAnswerPage only when it will actually emit a
-        // QAPage for this discussion, i.e. when "crawl all posts" is enabled,
-        // best-answer is installed, and this is a Q&A discussion. In every other
-        // case (no best-answer, non-Q&A, crawler off) we emit the standard
-        // DiscussionForumPosting here.
-        if (
-            $this->settingsRepositoryInterface->get('seo_post_crawler', 0) == 1 &&
-            $tagsEnabled && $enableBestAnswer && $discussionTags->contains(fn (Tag $tag) => (bool) $tag->is_qna || (bool) $tag->parent?->is_qna)
-        ) {
-            return;
+        // Defer to DiscussionBestAnswerPage when it will actually emit a QAPage
+        // for this discussion: best-answer installed, this is a Q&A discussion,
+        // and either the post crawler is on (full QAPage) or an accepted answer
+        // exists (lightweight QAPage with just that answer). In every other case
+        // (no best-answer, non-Q&A, crawler off without an accepted answer) we
+        // emit the standard DiscussionForumPosting here.
+        $isQna = $tagsEnabled && $enableBestAnswer && $discussionTags->contains(fn (Tag $tag) => (bool) $tag->is_qna || (bool) $tag->parent?->is_qna);
+
+        if ($isQna) {
+            $crawlerEnabled = $this->settingsRepositoryInterface->get('seo_post_crawler', 0) == 1;
+
+            if ($crawlerEnabled || $discussion->best_answer_post_id !== null) {
+                return;
+            }
         }
 
         // Get seo-meta-date

--- a/tests/integration/forum/BestAnswerPageTest.php
+++ b/tests/integration/forum/BestAnswerPageTest.php
@@ -389,21 +389,56 @@ class BestAnswerPageTest extends ForumHtmlTestCase
         $this->assertSame(1, $question['upvoteCount'] ?? null);
     }
 
+    /**
+     * Even with the post crawler OFF, a Q&A discussion that has an accepted
+     * best answer should emit a QAPage with that answer as `acceptedAnswer`.
+     * The best-answer post is already loaded, so this is cheap and gives Google
+     * the richest result for Q&A threads without enabling full post crawling.
+     */
     #[Test]
-    public function regular_discussion_schema_is_used_when_post_crawler_disabled(): void
+    public function qa_discussion_with_accepted_answer_emits_qapage_even_with_crawler_off(): void
     {
-        // seo_post_crawler defaults to off — no QAPage even for a Q&A discussion.
-        $this->seedQnaDiscussion();
+        // seo_post_crawler defaults to off.
+        $this->seedQnaDiscussion(); // best_answer_post_id => 2
+
+        $html = $this->fetchForumHtml('/d/1-how-do-i-bake-bread');
+
+        $qaPage = $this->findSchemaEntry($html, 'QAPage');
+        $this->assertNotNull($qaPage, 'A Q&A discussion with an accepted answer should emit QAPage even with the crawler off.');
+        $this->assertNull(
+            $this->findSchemaEntry($html, 'DiscussionForumPosting'),
+            'QAPage and DiscussionForumPosting must not both be emitted.'
+        );
+
+        $accepted = $qaPage['mainEntity']['acceptedAnswer'] ?? null;
+        $this->assertSame('Answer', $accepted['@type'] ?? null);
+        $this->assertStringContainsString('Use flour, water and yeast.', $accepted['text'] ?? '');
+
+        // With the crawler off we only surface the accepted answer, not the
+        // full thread of suggested answers (that is the crawler-on behaviour).
+        $this->assertSame([], $qaPage['mainEntity']['suggestedAnswer'] ?? null);
+    }
+
+    /**
+     * A Q&A discussion with NO accepted answer stays a plain
+     * DiscussionForumPosting when the crawler is off (decided behaviour: we do
+     * not emit a QAPage without an answer).
+     */
+    #[Test]
+    public function qa_discussion_without_accepted_answer_falls_back_to_forum_posting_when_crawler_off(): void
+    {
+        // Q&A discussion, crawler off, but no best answer set.
+        $this->seedQnaDiscussion(['best_answer_post_id' => null]);
 
         $html = $this->fetchForumHtml('/d/1-how-do-i-bake-bread');
 
         $this->assertNull(
             $this->findSchemaEntry($html, 'QAPage'),
-            'QAPage must not be emitted unless seo_post_crawler is enabled.'
+            'No QAPage should be emitted for a Q&A discussion without an accepted answer.'
         );
         $this->assertNotNull(
             $this->findSchemaEntry($html, 'DiscussionForumPosting'),
-            'A normal discussion should emit DiscussionForumPosting.'
+            'Without an accepted answer the discussion falls back to DiscussionForumPosting.'
         );
     }
 


### PR DESCRIPTION
> **Target branch: `2.x`** (Flarum 2.x).

## What

When the post crawler (`seo_post_crawler`) is **off**, a Q&A discussion with an accepted best answer used to fall back to a plain `DiscussionForumPosting`, hiding the answer from Google. This emits a `QAPage` with the accepted answer in that case.

- **Crawler off + Q&A + accepted answer** → `QAPage` with the question and `acceptedAnswer` only. Cheap: just the best-answer post is loaded (it is already known via `best_answer_post_id`), so there is no full-thread query or render.
- **Crawler off + Q&A + no accepted answer** → unchanged: plain `DiscussionForumPosting` (we don't emit a QAPage without an answer).
- **Crawler on** → unchanged: full `QAPage` with all suggested answers.

## How

- `DiscussionBestAnswerPage` no longer hard-returns when the crawler is off; instead it returns only when there is no accepted answer to surface, and restricts its answer query to the best-answer post in the crawler-off case.
- `DiscussionPage`'s deferral is widened to match, so exactly one schema type (QAPage **or** DiscussionForumPosting) is emitted per discussion. The two conditions are kept in lock-step.

## Notes

The Question/Answer `text` still uses the pre-existing `strip_tags($post->content)` source; improving that to rendered plain text (as done for `DiscussionForumPosting` comments) is out of scope here.