### PR TITLE
[2.x] fix: render QAPage question/answer text to plain text

### DIFF
--- a/src/Page/DiscussionBestAnswerPage.php
+++ b/src/Page/DiscussionBestAnswerPage.php
@@ -17,6 +17,7 @@ use Flarum\Extension\ExtensionManager;
 use Flarum\Foundation\DispatchEventsTrait;
 use Flarum\Http\SlugManager;
 use Flarum\Http\UrlGenerator;
+use Flarum\Post\CommentPost;
 use Flarum\Post\Post;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Tags\Tag;
@@ -71,6 +72,16 @@ class DiscussionBestAnswerPage implements PageDriverInterface
             'name'  => $user->getDisplayNameAttribute(),
             'url'   => $this->urlGenerator->to('forum')->route('user', ['username' => $this->slugManager->forResource(User::class)->toSlug($user)]),
         ];
+    }
+
+    /**
+     * Render a post's stored content to plain text for a schema `text` field:
+     * render to HTML so mentions/links resolve, then decode entities and strip
+     * tags. Mirrors the DiscussionForumPosting comment handling (PR #141).
+     */
+    private function plainText(CommentPost $post): string
+    {
+        return trim(html_entity_decode(strip_tags($post->formatContent()), ENT_QUOTES | ENT_HTML5));
     }
 
     public function extensionDependencies(): array
@@ -179,7 +190,7 @@ class DiscussionBestAnswerPage implements PageDriverInterface
         $mainEntity = [
             '@type'       => 'Question',
             'name'        => $seoMeta->title,
-            'text'        => $firstPost !== null ? strip_tags($firstPost->content) : '',
+            'text'        => $firstPost instanceof CommentPost ? $this->plainText($firstPost) : '',
             'dateCreated' => $seoMeta->created_at,
             'author'      => $this->authorSchema($discussion->user),
             'answerCount' => $discussion->comment_count - 1,
@@ -226,14 +237,14 @@ class DiscussionBestAnswerPage implements PageDriverInterface
 
         foreach ($posts as $post) {
             /** @var Post $post */
-            if ($post->is_private || $post->type !== 'comment') {
+            if ($post->is_private || !$post instanceof CommentPost) {
                 continue;
             }
 
             // Temp post
             $generatedPost = [
                 '@type'       => 'Answer',
-                'text'        => strip_tags($post->content),
+                'text'        => $this->plainText($post),
                 'dateCreated' => $post->created_at->toIso8601String(),
                 'url'         => $this->urlGenerator->to('forum')->route('discussion', ['id' => $discussion->id.'-'.$discussion->slug, 'near' => $post->number]),
                 'author'      => $this->authorSchema($post->user),

--- a/tests/integration/forum/BestAnswerPageTest.php
+++ b/tests/integration/forum/BestAnswerPageTest.php
@@ -211,6 +211,52 @@ class BestAnswerPageTest extends ForumHtmlTestCase
     }
 
     /**
+     * The Question and Answer `text` must be plain text rendered from the
+     * stored markup — not the raw source. Markup is stripped, links reduce to
+     * their visible label, and HTML entities are decoded (matching the
+     * DiscussionForumPosting comment behaviour).
+     */
+    #[Test]
+    public function question_and_answer_text_is_rendered_to_plain_text(): void
+    {
+        $this->setting('seo_post_crawler', '1');
+
+        $now = Carbon::now();
+
+        // The accepted answer contains a labelled markdown link. The raw stored
+        // source keeps the `[label](url)` syntax, so the old strip_tags(content)
+        // path would leak it; rendering to HTML reduces it to the label.
+        $this->prepareDatabase([
+            Tag::class => [
+                ['id' => self::QNA_TAG_ID, 'name' => 'Questions', 'slug' => 'questions', 'description' => null, 'color' => '#000', 'position' => 0, 'is_restricted' => false, 'is_hidden' => false, 'is_qna' => true],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'How do I bake bread?', 'slug' => 'how-do-i-bake-bread', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 2, 'best_answer_post_id' => 2, 'created_at' => $now, 'last_posted_at' => $now],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<r><p>Flour <STRONG>and</STRONG> water?</p></r>', 'created_at' => $now],
+                ['id' => 2, 'discussion_id' => 1, 'number' => 2, 'user_id' => 1, 'type' => 'comment', 'content' => '<r><p>Yes &amp; yeast, read <URL url="https://example.com"><s>[</s>the docs<e>](https://example.com)</e></URL></p></r>', 'created_at' => $now],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => self::QNA_TAG_ID],
+            ],
+        ]);
+
+        $question = $this->findSchemaEntry($this->fetchForumHtml('/d/1-how-do-i-bake-bread'), 'QAPage')['mainEntity'] ?? [];
+
+        // Question text: markup stripped, plain text only.
+        $this->assertSame('Flour and water?', $question['text'] ?? null);
+
+        // Answer text: link reduced to its label, entity decoded, no markdown
+        // link syntax leaked.
+        $answer = $question['acceptedAnswer']['text'] ?? '';
+        $this->assertSame('Yes & yeast, read the docs', $answer);
+        $this->assertStringNotContainsString('](', $answer);
+        $this->assertStringNotContainsString('https://example.com', $answer);
+        $this->assertStringNotContainsString('&amp;', $answer);
+    }
+
+    /**
      * The optional flarum/likes integration: when it's enabled, an answer's
      * `upvoteCount` reflects its like count.
      */


### PR DESCRIPTION
> **Target branch: `2.x`** (Flarum 2.x).

## What

The `QAPage` Question and Answer `text` fields used `strip_tags($post->content)`, which operates on the **unparsed source**. As a result:

- mentions appeared as raw `@"Name"#id` syntax instead of the display name;
- labelled markdown links leaked their `[label](url)` form instead of the visible label.

This left the QAPage — Google's richest forum result — with worse text than the plain `DiscussionForumPosting`, which #141 already fixed.

## Fix

Render the stored content to HTML first (so mentions and links resolve), then decode entities and strip tags, via a shared `plainText()` helper. Mirrors the `DiscussionForumPosting` comment handling from #141, so both schema types now expose clean plain text.

The answer-loop guard also moves from `$post->type !== 'comment'` to the equivalent `!$post instanceof CommentPost`, which narrows the type for `formatContent()`.

Follow-up to #144 (noted there as out of scope).