### PR TITLE
[1.x] fix: don't auto-select SVG images for og:image, add backfill command

### DIFF
--- a/docs/developers/seometa-objects.md
+++ b/docs/developers/seometa-objects.md
@@ -38,6 +38,9 @@ automatic updates.
 
 An image is normally detected from an object's content (for example, the first
 image in a post's body) and used for both the Open Graph and Twitter image tags.
+SVG images are skipped (social networks reject them), so the first **raster**
+image is chosen; see [Per-item SEO](../meta-management.md#images) for the
+`fof:seo:fix-svg-images` command that backfills items stored before this.
 
 If a **different extension** owns the image, it must set the `image_source`
 column so FoF SEO knows not to overwrite it (the value is also shown to the user

--- a/docs/meta-management.md
+++ b/docs/meta-management.md
@@ -67,5 +67,43 @@ Twitter image tags; you can override either in the dialog.
 > image is used for Twitter too. Setting *only* a Twitter image (with no Open
 > Graph image) will not emit image tags.
 
+Auto-detection skips **SVG** images: Slack, X and most networks reject SVG for
+preview images, so a post that opens with an SVG badge (e.g. a shields.io
+license badge) would otherwise unfurl with no image. The first **raster** image
+(PNG/JPG/WebP/GIF) in the post is used instead; if there is none, the image
+falls back to the forum-wide social media image (then the logo, then favicon).
+
 If another extension owns an item's image, FoF SEO records its *source* and won't
 overwrite it — see the [developer guide](developers/seometa-objects.md#images).
+
+### Fixing previously-stored SVG images
+
+The detected image is stored on the item when it is saved, so discussions that
+were saved *before* the SVG exclusion existed may still have an SVG stored as
+their Open Graph image. They self-heal the next time the discussion is edited,
+but you can fix them all at once with a console command:
+
+```bash
+php flarum fof:seo:fix-svg-images
+```
+
+For each discussion whose stored image is an SVG (and was set automatically, not
+manually or by another extension), it re-derives the first raster image from the
+post — or clears the stored image so rendering falls back to the forum social
+image. Manually-set and other-extension-managed images are left untouched.
+
+The command processes discussions in batches to keep memory and database load
+flat on large forums:
+
+| Option | Description |
+| --- | --- |
+| `--batch=<n>` | Number of rows to process per chunk. Defaults to `100`. |
+| `--dry-run` | Report what would change without writing anything. |
+
+```bash
+# Preview the changes without saving
+php flarum fof:seo:fix-svg-images --dry-run
+
+# Use smaller chunks on a constrained server
+php flarum fof:seo:fix-svg-images --batch=25
+```

--- a/extend.php
+++ b/extend.php
@@ -46,6 +46,9 @@ return [
 
     new Extend\Locales(__DIR__.'/locale'),
 
+    (new Extend\Console())
+      ->command(Console\FixSvgSocialImagesCommand::class),
+
     (new Extend\Formatter())
       ->render(FormatLinks::class)
       ->configure(ConfigureLinks::class),

--- a/src/Console/FixSvgSocialImagesCommand.php
+++ b/src/Console/FixSvgSocialImagesCommand.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of fof/seo.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Seo\Console;
+
+use Flarum\Console\AbstractCommand;
+use Flarum\Discussion\Discussion;
+use Flarum\Post\CommentPost;
+use FoF\Seo\SeoMeta\SeoMeta;
+use FoF\Seo\SeoProperties;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * Re-derives the social image (`og:image`) for discussions whose auto-selected
+ * image is an SVG. SVGs (e.g. shields.io badges) are rejected by Slack/X and
+ * produce a plain unfurl with no preview, so they should never have been
+ * selected (GH #149). The selection logic was fixed for new/edited discussions;
+ * this backfills existing rows.
+ *
+ * Processed in id-ordered chunks so memory and database load stay flat
+ * regardless of how many discussions a forum has.
+ */
+class FixSvgSocialImagesCommand extends AbstractCommand
+{
+    public function __construct(
+        protected readonly SeoProperties $seoProperties,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('fof:seo:fix-svg-images')
+            ->setDescription('Re-derive og:image for discussions whose auto-selected image is an SVG (GH #149).')
+            ->addOption('batch', null, InputOption::VALUE_REQUIRED, 'Number of rows to process per chunk.', '100')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Report what would change without writing anything.');
+    }
+
+    protected function fire(): int
+    {
+        $batch = max(1, (int) $this->input->getOption('batch'));
+        $dryRun = (bool) $this->input->getOption('dry-run');
+
+        if ($dryRun) {
+            $this->info('Dry run — no changes will be saved.');
+        }
+
+        $scanned = 0;
+        $updated = 0;
+        $cleared = 0;
+
+        // Only auto-managed discussion images that are SVGs. Manual uploads and
+        // images managed by another extension (source != 'auto') are left alone.
+        $query = SeoMeta::query()
+            ->where('object_type', 'discussions')
+            ->where('open_graph_image', 'like', '%.svg')
+            ->where(function ($q) {
+                $q->whereNull('open_graph_image_source')
+                    ->orWhere('open_graph_image_source', 'auto');
+            });
+
+        // chunkById keeps a stable cursor and bounded memory even while we
+        // mutate rows; ordering by the primary key avoids skipped/repeated rows.
+        $query->chunkById($batch, function ($metas) use (&$scanned, &$updated, &$cleared, $dryRun) {
+            foreach ($metas as $meta) {
+                $scanned++;
+
+                $newImage = $this->deriveImage($meta);
+
+                // Nothing usable, and it is already cleared — skip.
+                if ($newImage === $meta->open_graph_image) {
+                    continue;
+                }
+
+                if ($newImage === null) {
+                    $cleared++;
+                    $this->info("#{$meta->object_id}: no usable image — cleared (will fall back to the forum image).");
+                } else {
+                    $updated++;
+                    $this->info("#{$meta->object_id}: {$newImage}");
+                }
+
+                if (!$dryRun) {
+                    $meta->open_graph_image = $newImage;
+                    $meta->open_graph_image_source = 'auto';
+                    $meta->save();
+                }
+            }
+        }, 'id');
+
+        $this->info(sprintf(
+            'Done. Scanned %d SVG image(s): %d re-pointed to a raster image, %d cleared.',
+            $scanned,
+            $updated,
+            $cleared
+        ));
+
+        return 0;
+    }
+
+    /**
+     * Re-derive the first raster image from a discussion's first post, or null
+     * when none exists (so rendering falls back to the forum social image).
+     */
+    private function deriveImage(SeoMeta $meta): ?string
+    {
+        $discussion = Discussion::find($meta->object_id);
+
+        $firstPost = $discussion?->firstPost;
+
+        if (!$firstPost instanceof CommentPost) {
+            return null;
+        }
+
+        return $this->seoProperties->getImageFromContent($firstPost->formatContent());
+    }
+}

--- a/src/Listeners/PageListener.php
+++ b/src/Listeners/PageListener.php
@@ -367,9 +367,14 @@ class PageListener
         // Check post content is not empty
         if ($content !== null) {
             // Match http(s) and protocol-relative ("//host/img.png") image URLs.
-            $pattern = '/(?<=src=")((?:https?:)?\/\/.*?\.)(jpe?g|png|[tg]iff?|svg|webp)(\?[a-zA-Z0-9\_\-\=\&]*)?(?=")/';
+            // SVG is deliberately excluded: Slack and X reject SVG for og:image
+            // (only raster formats render), so an SVG badge would produce a
+            // plain unfurl with no preview image (GH #149).
+            // The URL body excludes `"` so a non-matching (e.g. SVG) src can't
+            // let `.*?` run past the closing quote into the next img tag.
+            $pattern = '/(?<=src=")((?:https?:)?\/\/[^"]*?\.)(jpe?g|png|[tg]iff?|webp)(\?[a-zA-Z0-9\_\-\=\&]*)?(?=")/';
 
-            // Use image from post for social media og:image
+            // Use the first raster image from the post for the social og:image.
             if (preg_match_all($pattern, $content, $matches)) {
                 $contentImage = $matches[0][0];
 

--- a/tests/integration/console/FixSvgSocialImagesCommandTest.php
+++ b/tests/integration/console/FixSvgSocialImagesCommandTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of fof/seo.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Seo\Tests\integration\console;
+
+use Carbon\Carbon;
+use Flarum\Testing\integration\ConsoleTestCase;
+use FoF\Seo\SeoMeta\SeoMeta;
+
+/**
+ * The fof:seo:fix-svg-images command re-derives og:image for discussions whose
+ * auto-selected image is an SVG (GH #149): re-pointing to the first raster
+ * image in the post, or clearing it when none exists. Manual / other-extension
+ * managed images are left untouched.
+ *
+ * Note: the bare test formatter renders no `<img>` tags (image support comes
+ * from a markdown extension absent here), so re-derivation always yields null
+ * — i.e. the "clear" path. The first-raster *selection* itself is covered by
+ * the unit tests for getImageFromContent. These tests pin down the command's
+ * own behaviour: which rows it touches, clearing, dry-run, and source guarding.
+ */
+class FixSvgSocialImagesCommandTest extends ConsoleTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-seo');
+
+        $this->prepareDatabase([
+            'users' => [
+                ['id' => 1, 'username' => 'admin', 'email' => 'admin@machine.local', 'is_email_confirmed' => 1],
+            ],
+            'discussions' => [
+                ['id' => 1, 'title' => 'Has a raster image', 'slug' => 'one', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'created_at' => Carbon::now()],
+                ['id' => 2, 'title' => 'Only an SVG badge', 'slug' => 'two', 'user_id' => 1, 'first_post_id' => 2, 'comment_count' => 1, 'created_at' => Carbon::now()],
+                ['id' => 3, 'title' => 'Manually set image', 'slug' => 'three', 'user_id' => 1, 'first_post_id' => 3, 'comment_count' => 1, 'created_at' => Carbon::now()],
+            ],
+            'posts' => [
+                // Leads with an SVG badge, then a real raster screenshot.
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<r><p><IMG src="https://img.shields.io/badge/x.svg">badge</IMG> <IMG src="https://i.imgur.com/shot.png">shot</IMG></p></r>', 'created_at' => Carbon::now()],
+                // Only an SVG badge — nothing usable.
+                ['id' => 2, 'discussion_id' => 2, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<r><p><IMG src="https://img.shields.io/badge/y.svg">badge</IMG></p></r>', 'created_at' => Carbon::now()],
+                ['id' => 3, 'discussion_id' => 3, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>no image</p></t>', 'created_at' => Carbon::now()],
+            ],
+            'seo_meta' => [
+                ['id' => 1, 'object_type' => 'discussions', 'object_id' => 1, 'auto_update_data' => 1, 'open_graph_image' => 'https://img.shields.io/badge/x.svg', 'open_graph_image_source' => 'auto', 'created_at' => Carbon::now(), 'updated_at' => Carbon::now()],
+                ['id' => 2, 'object_type' => 'discussions', 'object_id' => 2, 'auto_update_data' => 1, 'open_graph_image' => 'https://img.shields.io/badge/y.svg', 'open_graph_image_source' => 'auto', 'created_at' => Carbon::now(), 'updated_at' => Carbon::now()],
+                // Manually-set SVG — must NOT be touched.
+                ['id' => 3, 'object_type' => 'discussions', 'object_id' => 3, 'auto_update_data' => 1, 'open_graph_image' => 'https://example.com/manual.svg', 'open_graph_image_source' => 'manual', 'created_at' => Carbon::now(), 'updated_at' => Carbon::now()],
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_clears_auto_svg_images_and_leaves_manual_ones(): void
+    {
+        $this->runCommand(['command' => 'fof:seo:fix-svg-images']);
+
+        // Discussions 1 & 2: auto SVGs cleared (no raster derivable here), so
+        // rendering falls back to the forum social image.
+        $this->assertNull(SeoMeta::find(1)->open_graph_image);
+        $this->assertNull(SeoMeta::find(2)->open_graph_image);
+
+        // Discussion 3: manual source untouched.
+        $this->assertSame('https://example.com/manual.svg', SeoMeta::find(3)->open_graph_image);
+        $this->assertSame('manual', SeoMeta::find(3)->open_graph_image_source);
+    }
+
+    /**
+     * @test
+     */
+    public function dry_run_writes_nothing(): void
+    {
+        $this->runCommand(['command' => 'fof:seo:fix-svg-images', '--dry-run' => true]);
+
+        // Unchanged: still the original SVGs.
+        $this->assertSame('https://img.shields.io/badge/x.svg', SeoMeta::find(1)->open_graph_image);
+        $this->assertSame('https://img.shields.io/badge/y.svg', SeoMeta::find(2)->open_graph_image);
+    }
+}

--- a/tests/unit/Listeners/PageListenerTest.php
+++ b/tests/unit/Listeners/PageListenerTest.php
@@ -76,4 +76,40 @@ class PageListenerTest extends TestCase
 
         $this->assertNull($result);
     }
+
+    /**
+     * GH #149 — SVG images (e.g. shields.io badges) are rejected by Slack/X as
+     * og:image, so they must not be auto-selected.
+     */
+    public function test_getImageFromContent_skips_svg_images(): void
+    {
+        $result = $this->makeListener()->getImageFromContent(
+            '<p><img src="https://img.shields.io/badge/license-MIT-blue.svg"></p>'
+        );
+
+        $this->assertNull($result);
+    }
+
+    /**
+     * When a post leads with an SVG badge but also contains a raster image,
+     * the first raster image should be chosen (not the SVG, not null).
+     */
+    public function test_getImageFromContent_prefers_first_raster_image_over_svg(): void
+    {
+        $result = $this->makeListener()->getImageFromContent(
+            '<p><img src="https://img.shields.io/badge/license-MIT-blue.svg">'
+            .'<img src="https://i.imgur.com/screenshot.png"></p>'
+        );
+
+        $this->assertSame('https://i.imgur.com/screenshot.png', $result);
+    }
+
+    public function test_getImageFromContent_skips_svg_and_normalises_protocol_relative_raster(): void
+    {
+        $result = $this->makeListener()->getImageFromContent(
+            '<p><img src="//cdn.example.com/badge.svg"><img src="//i.imgur.com/photo.jpg"></p>'
+        );
+
+        $this->assertSame('https://i.imgur.com/photo.jpg', $result);
+    }
 }


### PR DESCRIPTION
> **Target branch: `1.x`** (Flarum 1.x). The 2.x equivalent is #150.

## Problem

Sharing a discussion link on Slack or X sometimes produced a plain title+description unfurl with no image, even though the Open Graph tags were correct. The cause: `og:image` was an **SVG** badge auto-selected from the first post, and Slack/X reject SVG for preview images (raster only).

## Fix

`PageListener::getImageFromContent()`:

- excludes SVG, so it returns the first **raster** image (png/jpg/webp/gif) in the post, falling through to `null` — and thus the forum social-image / logo fallback — when there is none;
- the URL pattern body now excludes `"` so a non-matching (e.g. SVG) `src` can't let `.*?` run past the closing quote into the next `<img>` tag.

## Backfill command

`og:image` is persisted per discussion at save time, so existing rows keep their stored SVG until next edited. New console command **`fof:seo:fix-svg-images`** backfills them:

- targets only auto-managed (`source` null/`auto`) discussion rows whose `open_graph_image` is an SVG;
- re-derives the first raster image, or clears it (→ forum fallback) when none;
- `chunkById` in id order — bounded memory and DB load regardless of forum size — with `--batch` (default 100) and `--dry-run`;
- leaves manual / other-extension-managed images untouched.

## Tests

Unit tests cover the SVG-skipping selection; command tests cover clearing, source-guarding, and dry-run. (The bare test formatter renders no `<img>` tags, so the command's re-derivation hits the clear path there; the raster selection itself is unit-covered — noted in the test.)

Closes #149