### PR TITLE
[2.x] docs: document SVG image exclusion and the fix-svg-images command

### DIFF
--- a/docs/developers/seometa-objects.md
+++ b/docs/developers/seometa-objects.md
@@ -38,6 +38,9 @@ automatic updates.
 
 An image is normally detected from an object's content (for example, the first
 image in a post's body) and used for both the Open Graph and Twitter image tags.
+SVG images are skipped (social networks reject them), so the first **raster**
+image is chosen; see [Per-item SEO](../meta-management.md#images) for the
+`fof:seo:fix-svg-images` command that backfills items stored before this.
 
 If a **different extension** owns the image, it must set the `image_source`
 column so FoF SEO knows not to overwrite it (the value is also shown to the user

--- a/docs/meta-management.md
+++ b/docs/meta-management.md
@@ -67,5 +67,43 @@ Twitter image tags; you can override either in the dialog.
 > image is used for Twitter too. Setting *only* a Twitter image (with no Open
 > Graph image) will not emit image tags.
 
+Auto-detection skips **SVG** images: Slack, X and most networks reject SVG for
+preview images, so a post that opens with an SVG badge (e.g. a shields.io
+license badge) would otherwise unfurl with no image. The first **raster** image
+(PNG/JPG/WebP/GIF) in the post is used instead; if there is none, the image
+falls back to the forum-wide social media image (then the logo, then favicon).
+
 If another extension owns an item's image, FoF SEO records its *source* and won't
 overwrite it — see the [developer guide](developers/seometa-objects.md#images).
+
+### Fixing previously-stored SVG images
+
+The detected image is stored on the item when it is saved, so discussions that
+were saved *before* the SVG exclusion existed may still have an SVG stored as
+their Open Graph image. They self-heal the next time the discussion is edited,
+but you can fix them all at once with a console command:
+
+```bash
+php flarum fof:seo:fix-svg-images
+```
+
+For each discussion whose stored image is an SVG (and was set automatically, not
+manually or by another extension), it re-derives the first raster image from the
+post — or clears the stored image so rendering falls back to the forum social
+image. Manually-set and other-extension-managed images are left untouched.
+
+The command processes discussions in batches to keep memory and database load
+flat on large forums:
+
+| Option | Description |
+| --- | --- |
+| `--batch=<n>` | Number of rows to process per chunk. Defaults to `100`. |
+| `--dry-run` | Report what would change without writing anything. |
+
+```bash
+# Preview the changes without saving
+php flarum fof:seo:fix-svg-images --dry-run
+
+# Use smaller chunks on a constrained server
+php flarum fof:seo:fix-svg-images --batch=25
+```


### PR DESCRIPTION
> **Target branch: `2.x`** (Flarum 2.x). Documents the change shipped in #150 (already merged). The 1.x docs are added directly to the 1.x code PR #156.

Adds documentation for the og:image SVG handling from #150:

- **Per-item SEO guide** (`docs/meta-management.md`) — notes that auto image detection skips SVG (raster only), and documents the new **`fof:seo:fix-svg-images`** console command with its `--batch` and `--dry-run` options.
- **Developer SeoMeta guide** (`docs/developers/seometa-objects.md`) — a brief note on the SVG skip with a cross-reference to the command.

Docs-only.

Refs #149