### PR TITLE
[1.x] fix: add bottom margin to SEO admin page container

### DIFF
--- a/less/admin/Page.less
+++ b/less/admin/Page.less
@@ -29,6 +29,19 @@
     line-height: 25px;
   }
 
+  // Keep the page content (and its trailing "I have read this" CTA) from
+  // butting up against the next admin section (GH #154). The CTA floats right,
+  // so clear the float to make the bottom margin apply below it.
+  .FlarumSeoPage-container {
+    margin-bottom: 30px;
+
+    &::after {
+      content: "";
+      display: block;
+      clear: both;
+    }
+  }
+
   .seo-check-table {
     width: 100%;
     margin-top: 30px;
@@ -103,7 +116,8 @@
   .FlarumSEO {
     .FlarumSeoPage-container {
       max-width: 600px;
-      margin: 0;
+      // Keep the bottom margin (GH #154); only the top/side margins are reset.
+      margin: 0 0 30px;
     }
   }
 }


### PR DESCRIPTION
> **Target branch: `1.x`** (Flarum 1.x). The 2.x equivalent is #161.

## Problem

On the *search engine information* admin page, the "I have read this" CTA button floated to the right of the page container with no spacing beneath it, so it blended into the next admin section (the permissions header). #154

## Fix

`less/admin/Page.less`:

- give `.FlarumSeoPage-container` a `margin-bottom: 30px` — and keep it in the `≥992px` media query, which previously reset the container to `margin: 0`;
- add a clearfix (`::after { clear: both }`) so the floated CTA is contained and the bottom margin applies below it.

LESS-only; Flarum compiles it at runtime, so there is no JS build artifact to regenerate.

Closes #154