### PR TITLE
[2.x] fix: restore SeoWidget CTA contrast on the dashboard

### DIFF
--- a/less/admin/Widget.less
+++ b/less/admin/Widget.less
@@ -16,9 +16,14 @@
             margin-right: 15px;
         }
 
-        button {
+        // The CTA is a LinkButton, which renders an `<a class="LinkButton">`
+        // (no `Button` class in Flarum 2.x) — not a `<button>` — so the old
+        // `button` selector never matched and the CTA was invisible on the
+        // widget's blue background (GH #159). Target `.LinkButton` instead.
+        .LinkButton {
             background: #FFFFFF;
             border: 0;
+            text-decoration: none;
             -webkit-border-radius: 3px;
             -moz-border-radius: 3px;
             border-radius: 3px;
@@ -34,7 +39,15 @@
             -o-transition: all 250ms ease-in-out;
             transition: all 250ms ease-in-out;
 
-            &:hover {
+            &,
+            .Button-label {
+                color: #0072ff;
+            }
+
+            &:hover,
+            &:focus {
+                color: #0072ff;
+                text-decoration: none;
                 transform: scale(1.1);
             }
         }


### PR DESCRIPTION
> **Target branch: `2.x`** (Flarum 2.x). A 1.x mirror will follow — this PR does **not** close #159.

## Problem

The admin dashboard's SEO widget shows a "Do the health-check" CTA that rendered with no white pill and low-contrast text on the widget's blue background — barely visible (#159).

## Root cause

`less/admin/Widget.less` styled the CTA white via `.SeoWidget button { … }`. But the CTA is a `LinkButton`, and in Flarum 2.x it renders an `<a class="LinkButton hasIcon">` — **not** a `<button>`, and **without** a `Button` class (2.x's `Button` only adds button styling when `className="Button"` is passed explicitly). So the `button` selector never matched and the CTA stayed unstyled.

Confirmed against the rendered DOM:
```html
<a class="LinkButton hasIcon" href="#/extension/fof-seo" active="false">
  <i class="icon far fa-thumbs-up Button-icon"></i>
  <span class="Button-label"><span class="Button-labelText">Do the health-check!</span></span>
</a>
```

## Fix

Target `.LinkButton` (the actual rendered class), and pin the text colour across the anchor's normal/hover/focus states and `.Button-label`.

LESS-only — no JS change and no `js/dist` rebuild needed; Flarum recompiles the CSS at runtime (clear the asset cache to pick it up).

Refs #159