### PR TITLE
[1.x] fix: restore SeoWidget CTA contrast on the dashboard

### DIFF
--- a/less/admin/Widget.less
+++ b/less/admin/Widget.less
@@ -16,9 +16,14 @@
             margin-right: 15px;
         }
 
-        button {
+        // The CTA is a LinkButton, which renders an `<a class="LinkButton">`
+        // (no `Button` class in Flarum) — not a `<button>` — so the old
+        // `button` selector never matched and the CTA was invisible on the
+        // widget's blue background (GH #159). Target `.LinkButton` instead.
+        .LinkButton {
             background: #FFFFFF;
             border: 0;
+            text-decoration: none;
             -webkit-border-radius: 3px;
             -moz-border-radius: 3px;
             border-radius: 3px;
@@ -34,7 +39,15 @@
             -o-transition: all 250ms ease-in-out;
             transition: all 250ms ease-in-out;
 
-            &:hover {
+            &,
+            .Button-label {
+                color: #0072ff;
+            }
+
+            &:hover,
+            &:focus {
+                color: #0072ff;
+                text-decoration: none;
                 transform: scale(1.1);
             }
         }


### PR DESCRIPTION
> **Target branch: `1.x`** (Flarum 1.x). The 2.x equivalent is #163.

## Problem

The admin dashboard's SEO widget shows a "Do the health-check" CTA that rendered with no white pill and low-contrast text on the widget's blue background (#159).

## Root cause

`less/admin/Widget.less` styled the CTA white via `.SeoWidget button { … }`, but the CTA is a `LinkButton`, which renders an `<a class="LinkButton">` — not a `<button>`, and without a `Button` class. So the `button` selector never matched. (Verified that 1.x's `LinkButton`/`Button` render identically to 2.x: the tag is rewritten to `Link`, and the label is wrapped in `.Button-label`.)

## Fix

Target `.LinkButton` (the actual rendered class), pin the text colour across the anchor's normal/hover/focus states and `.Button-label`, and remove the anchor's hover underline.

LESS-only — no JS change and no `js/dist` rebuild; Flarum recompiles the CSS at runtime (clear the asset cache to pick it up).

Closes #159