### PR TITLE
[1.x] fix: restore SeoWidget CTA white pill on the dashboard

### DIFF
--- a/js/src/admin/components/SeoWidget.tsx
+++ b/js/src/admin/components/SeoWidget.tsx
@@ -27,7 +27,7 @@ export default class SeoWidget extends DashboardWidget {
     return (
       <div>
         {icon('fas fa-check seo-check-icon')} {app.translator.trans('fof-seo.admin.dashboard.widget.review_prompt')}
-        <LinkButton className="" icon="far fa-thumbs-up" href={app.route('extension', { id: 'fof-seo' })}>
+        <LinkButton className="Button SeoWidget-cta" icon="far fa-thumbs-up" href={app.route('extension', { id: 'fof-seo' })}>
           {app.translator.trans('fof-seo.admin.dashboard.widget.cta')}
         </LinkButton>
       </div>

--- a/less/admin/Widget.less
+++ b/less/admin/Widget.less
@@ -16,11 +16,12 @@
             margin-right: 15px;
         }
 
-        // The CTA is a LinkButton, which renders an `<a class="LinkButton">`
-        // (no `Button` class in Flarum) — not a `<button>` — so the old
-        // `button` selector never matched and the CTA was invisible on the
-        // widget's blue background (GH #159). Target `.LinkButton` instead.
-        .LinkButton {
+        // The CTA's `className` prop *replaces* the element class, so an empty
+        // string left the anchor with no `Button`/`LinkButton` hook and the
+        // styling never matched — the CTA stayed invisible on the widget's blue
+        // background (GH #159). The component now sets `Button SeoWidget-cta`;
+        // target that explicit class so the white pill always applies.
+        .SeoWidget-cta {
             background: #FFFFFF;
             border: 0;
             text-decoration: none;


### PR DESCRIPTION
The dashboard SEO widget's "Do the health-check!" CTA rendered with no white pill.

The CTA passed `className=""` to `LinkButton`. Flarum's `Button` uses the `className` prop as the element's class rather than merging it onto a base, so the empty string left the anchor with no `Button`/`LinkButton` hook — only the auto-added `hasIcon` class. Both the original `button` selector and the later `.LinkButton` selector (#164) missed it, so the styling never applied.

This sets `className="Button SeoWidget-cta"` on the CTA and targets `.SeoWidget-cta` in `Widget.less`.

Verified locally: the white pill renders with blue uppercase text, and hover/focus keeps the text colour with no underline.

Closes #159
