### PR TITLE
[2.x] fix: Omit author when the user is deleted in structured data

### DIFF
--- a/src/Page/DiscussionBestAnswerPage.php
+++ b/src/Page/DiscussionBestAnswerPage.php
@@ -29,7 +29,6 @@ use FoF\Seo\TagIndexingPolicy;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DiscussionBestAnswerPage implements PageDriverInterface
 {
@@ -46,25 +45,25 @@ class DiscussionBestAnswerPage implements PageDriverInterface
         Dispatcher $events,
         protected readonly SlugManager $slugManager,
         protected readonly TagIndexingPolicy $tagIndexingPolicy,
-        protected readonly TranslatorInterface $translator,
     ) {
         $this->events = $events;
     }
 
     /**
-     * Build a schema.org Person for a question/answer author. `author` is a
-     * required field, so a deleted user falls back to the localized "[deleted]"
-     * display name with no profile url rather than `name: null` (GH #140).
+     * Build a schema.org Person for a question/answer author, or null when the
+     * user has been deleted. Google's QAPage guidance expects `author.url` to
+     * be "a link to a web page that uniquely identifies the author" — a profile
+     * page. A deleted user has no such page, and emitting an `author` Person
+     * without a `url` trips Search Console's "Missing field 'url' (in
+     * 'mainEntity.author')". Since `author` is recommended rather than required,
+     * callers omit it entirely when this returns null (GH #140).
      *
-     * @return array<string, string>
+     * @return array<string, string>|null
      */
-    private function authorSchema(?User $user): array
+    private function authorSchema(?User $user): ?array
     {
         if ($user === null) {
-            return [
-                '@type' => 'Person',
-                'name'  => $this->translator->trans('core.lib.username.deleted_text'),
-            ];
+            return null;
         }
 
         return [
@@ -192,9 +191,13 @@ class DiscussionBestAnswerPage implements PageDriverInterface
             'name'        => $seoMeta->title,
             'text'        => $firstPost instanceof CommentPost ? $this->plainText($firstPost) : '',
             'dateCreated' => $seoMeta->created_at,
-            'author'      => $this->authorSchema($discussion->user),
             'answerCount' => $discussion->comment_count - 1,
         ];
+
+        // Omit `author` when the starter is deleted — see authorSchema().
+        if (($questionAuthor = $this->authorSchema($discussion->user)) !== null) {
+            $mainEntity['author'] = $questionAuthor;
+        }
 
         // Upvotes on the question itself (the first post), when likes are available.
         if ($enableLikes && $firstPost !== null) {
@@ -247,8 +250,12 @@ class DiscussionBestAnswerPage implements PageDriverInterface
                 'text'        => $this->plainText($post),
                 'dateCreated' => $post->created_at->toIso8601String(),
                 'url'         => $this->urlGenerator->to('forum')->route('discussion', ['id' => $discussion->id.'-'.$discussion->slug, 'near' => $post->number]),
-                'author'      => $this->authorSchema($post->user),
             ];
+
+            // Omit `author` when this post's user is deleted — see authorSchema().
+            if (($answerAuthor = $this->authorSchema($post->user)) !== null) {
+                $generatedPost['author'] = $answerAuthor;
+            }
 
             // Upvote/like count
             $generatedPost['upvoteCount'] = $enableLikes ? $post->likes->count() : 0;

--- a/src/Page/DiscussionPage.php
+++ b/src/Page/DiscussionPage.php
@@ -29,7 +29,6 @@ use FoF\Seo\TagIndexingPolicy;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DiscussionPage implements PageDriverInterface
 {
@@ -46,26 +45,25 @@ class DiscussionPage implements PageDriverInterface
         Dispatcher $events,
         protected readonly SlugManager $slugManager,
         protected readonly TagIndexingPolicy $tagIndexingPolicy,
-        protected readonly TranslatorInterface $translator,
     ) {
         $this->events = $events;
     }
 
     /**
-     * Build a schema.org Person for a post/discussion author. `author` is a
-     * required field on DiscussionForumPosting and on each Comment (GH #140),
-     * so a deleted user falls back to the localized "[deleted]" display name
-     * with no profile url rather than being omitted.
+     * Build a schema.org Person for a post/discussion author, or null when the
+     * user has been deleted. Google's forum guidance expects `author.url` to
+     * link to a page identifying the author (a profile page). A deleted user
+     * has no such page, and emitting an `author` Person without a `url` trips
+     * Search Console's "Missing field 'url' (in 'author')". Since `author` is
+     * recommended rather than required, callers omit it entirely when this
+     * returns null (GH #140).
      *
-     * @return array<string, string>
+     * @return array<string, string>|null
      */
-    private function authorSchema(?User $user): array
+    private function authorSchema(?User $user): ?array
     {
         if ($user === null) {
-            return [
-                '@type' => 'Person',
-                'name'  => $this->translator->trans('core.lib.username.deleted_text'),
-            ];
+            return null;
         }
 
         return [
@@ -263,9 +261,10 @@ class DiscussionPage implements PageDriverInterface
                     'url'           => $this->urlGenerator->to('forum')->route('discussion', ['id' => $discussion->id.'-'.$discussion->slug, 'near' => $post->number]),
                 ];
 
-                // `author` is required on a Comment; deleted users fall back to
-                // a "[deleted]" Person rather than being omitted (GH #140).
-                $comment['author'] = $this->authorSchema($post->user);
+                // Omit `author` when the commenter is deleted — see authorSchema().
+                if (($commentAuthor = $this->authorSchema($post->user)) !== null) {
+                    $comment['author'] = $commentAuthor;
+                }
 
                 if ($enableLikes || $enableGamification) {
                     $count = 0;
@@ -294,8 +293,10 @@ class DiscussionPage implements PageDriverInterface
         }
 
         // author: https://schema.org/author typeof: https://schema.org/Person.
-        // Required field, so a deleted author falls back to "[deleted]" (#140).
-        $properties->setSchemaJson('author', $this->authorSchema($discussion->user));
+        // Omit `author` when the starter is deleted — see authorSchema() (#140).
+        if (($discussionAuthor = $this->authorSchema($discussion->user)) !== null) {
+            $properties->setSchemaJson('author', $discussionAuthor);
+        }
 
         // Generate a breadcrum if discussion has tags
         if ($tagsEnabled && $discussionTags->count() >= 1) {

--- a/tests/integration/forum/BestAnswerPageTest.php
+++ b/tests/integration/forum/BestAnswerPageTest.php
@@ -171,13 +171,15 @@ class BestAnswerPageTest extends ForumHtmlTestCase
     }
 
     /**
-     * `author` is required on a schema.org Answer/Question (GH #140). When an
-     * answer's author has been deleted, the QAPage must still emit an `author`
-     * Person with the localized "[deleted]" name and no null fields, rather
-     * than `name: null`.
+     * Google's QAPage guidance says `author.url` should be "a link to a web
+     * page that uniquely identifies the author" — a profile page. A deleted
+     * user has no such page, so emitting an `author` Person without a `url`
+     * trips Search Console's "Missing field 'url' (in 'mainEntity.author')".
+     * `author` is recommended, not required, so we omit it entirely when the
+     * user is gone rather than emit an incomplete Person (GH #140).
      */
     #[Test]
-    public function answer_by_deleted_user_still_has_a_named_author(): void
+    public function answer_by_deleted_user_omits_the_author(): void
     {
         $this->setting('seo_post_crawler', '1');
 
@@ -202,12 +204,71 @@ class BestAnswerPageTest extends ForumHtmlTestCase
 
         $accepted = $this->findSchemaEntry($this->fetchForumHtml('/d/1-how-do-i-bake-bread'), 'QAPage')['mainEntity']['acceptedAnswer'] ?? [];
 
-        $author = $accepted['author'] ?? null;
-        $this->assertIsArray($author);
-        $this->assertSame('Person', $author['@type'] ?? null);
-        $this->assertSame('[deleted]', $author['name'] ?? null);
-        // No profile exists for a deleted user, so no url should be emitted.
-        $this->assertArrayNotHasKey('url', $author);
+        // The answer itself is still emitted...
+        $this->assertSame('Answer', $accepted['@type'] ?? null);
+        // ...but with no `author`, since there is no profile to link to.
+        $this->assertArrayNotHasKey('author', $accepted);
+    }
+
+    /**
+     * The question author (`mainEntity.author`) follows the same rule: when the
+     * discussion starter has been deleted there is no profile page to link, so
+     * the `author` object is omitted rather than emitted without a `url`. This
+     * is the exact field Search Console flagged: "Missing field 'url' (in
+     * 'mainEntity.author')".
+     */
+    #[Test]
+    public function question_by_deleted_user_omits_the_author(): void
+    {
+        $this->setting('seo_post_crawler', '1');
+
+        $now = Carbon::now();
+
+        $this->prepareDatabase([
+            Tag::class => [
+                ['id' => self::QNA_TAG_ID, 'name' => 'Questions', 'slug' => 'questions', 'description' => null, 'color' => '#000', 'position' => 0, 'is_restricted' => false, 'is_hidden' => false, 'is_qna' => true],
+            ],
+            Discussion::class => [
+                // Started by a user that no longer exists (no row id 99).
+                ['id' => 1, 'title' => 'How do I bake bread?', 'slug' => 'how-do-i-bake-bread', 'user_id' => 99, 'first_post_id' => 1, 'comment_count' => 2, 'best_answer_post_id' => 2, 'created_at' => $now, 'last_posted_at' => $now],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 99, 'type' => 'comment', 'content' => '<t><p>How do I bake bread?</p></t>', 'created_at' => $now],
+                ['id' => 2, 'discussion_id' => 1, 'number' => 2, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Use flour and water.</p></t>', 'created_at' => $now],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => self::QNA_TAG_ID],
+            ],
+        ]);
+
+        $question = $this->findSchemaEntry($this->fetchForumHtml('/d/1-how-do-i-bake-bread'), 'QAPage')['mainEntity'] ?? [];
+
+        $this->assertSame('Question', $question['@type'] ?? null);
+        $this->assertArrayNotHasKey('author', $question);
+    }
+
+    /**
+     * A live author must still carry a `url` pointing at their profile page —
+     * the property Google recommends and that satisfies Search Console.
+     */
+    #[Test]
+    public function author_of_a_live_user_carries_a_profile_url(): void
+    {
+        $this->setting('seo_post_crawler', '1');
+        $this->seedQnaDiscussion();
+
+        $question = $this->findSchemaEntry($this->fetchForumHtml('/d/1-how-do-i-bake-bread'), 'QAPage')['mainEntity'] ?? [];
+
+        $questionAuthor = $question['author'] ?? null;
+        $this->assertIsArray($questionAuthor);
+        $this->assertSame('Person', $questionAuthor['@type'] ?? null);
+        $this->assertArrayHasKey('url', $questionAuthor);
+        $this->assertNotEmpty($questionAuthor['url']);
+
+        $answerAuthor = $question['acceptedAnswer']['author'] ?? null;
+        $this->assertIsArray($answerAuthor);
+        $this->assertArrayHasKey('url', $answerAuthor);
+        $this->assertNotEmpty($answerAuthor['url']);
     }
 
     /**
@@ -337,12 +398,17 @@ class BestAnswerPageTest extends ForumHtmlTestCase
     #[Test]
     public function qa_page_does_not_issue_per_answer_queries(): void
     {
-        // The per-answer N+1 this guards against lives in core's UserResource
-        // `groups` field getter (re-queries per serialized user, ignoring the
-        // eager-loaded relation) and is fixed in flarum/core 2.0.0-rc.3.
-        // See flarum/framework#4695. Skip on cores that still have the bug.
-        if (version_compare(Application::VERSION, '2.0.0-rc.3', '<')) {
-            $this->markTestSkipped('Core N+1 in UserResource groups getter, fixed in flarum/core 2.0.0-rc.3 — flarum/framework#4695');
+        // The per-answer N+1 this guards against lives in core: UserResource's
+        // `editCredentials`/`isAdmin` checks read `$user->groups` per serialized
+        // author. flarum/framework#4696 (in 2.0.0-rc.3) fixed this for the direct
+        // JSON:API posts endpoint by eager-loading `user.groups` — but it does
+        // NOT cover the forum HTML render path. There the same authors are
+        // serialized again through extra documents (the discussion's own `user`,
+        // `firstPost.user`, …) as `User` instances that lack the eager-loaded
+        // `groups` relation, so the lazy per-author query fires again. Tracked in
+        // flarum/framework#4724; expected to land in 2.0.0-rc.4. Skip until then.
+        if (version_compare(Application::VERSION, '2.0.0-rc.4', '<')) {
+            $this->markTestSkipped('Core N+1 in UserResource editCredentials/isAdmin on the forum render path — #4696 (rc.3) does not cover it; tracked in flarum/framework#4724, expected in 2.0.0-rc.4');
         }
 
         $this->extension('flarum-likes');

--- a/tests/integration/forum/DiscussionCommentsTest.php
+++ b/tests/integration/forum/DiscussionCommentsTest.php
@@ -97,13 +97,15 @@ class DiscussionCommentsTest extends ForumHtmlTestCase
      * dominant page-load cost, so the cap bounds it.
      */
     /**
-     * `author` is a required nested field on a schema.org Comment (GH #140).
-     * A reply whose author has been deleted must still emit an `author` Person
-     * with the localized "[deleted]" display name (and no profile url), rather
-     * than omitting the field entirely.
+     * Google's forum guidance says `author.url` should link to a page that
+     * identifies the author (a profile page). A deleted user has no such page,
+     * so emitting an `author` Person without a `url` trips Search Console's
+     * "Missing field 'url' (in 'author')". `author` is recommended, not
+     * required, so we omit it entirely for a deleted user rather than emit an
+     * incomplete Person (GH #140).
      */
     #[Test]
-    public function comment_by_deleted_user_still_has_an_author(): void
+    public function comment_by_deleted_user_omits_the_author(): void
     {
         $this->prepareDatabase([
             User::class => [
@@ -123,11 +125,10 @@ class DiscussionCommentsTest extends ForumHtmlTestCase
 
         $comment = $entry['comment'][0] ?? null;
         $this->assertIsArray($comment);
-        // The author field must be present and a Person with a name.
-        $this->assertSame('Person', $comment['author']['@type'] ?? null);
-        $this->assertSame('[deleted]', $comment['author']['name'] ?? null);
-        // A deleted user has no profile, so no url should be emitted.
-        $this->assertArrayNotHasKey('url', $comment['author']);
+        // The comment itself is still emitted...
+        $this->assertSame('Comment', $comment['@type'] ?? null);
+        // ...but with no `author`, since a deleted user has no profile to link.
+        $this->assertArrayNotHasKey('author', $comment);
     }
 
     #[Test]

--- a/tests/integration/forum/DiscussionPageTest.php
+++ b/tests/integration/forum/DiscussionPageTest.php
@@ -308,7 +308,37 @@ class DiscussionPageTest extends ForumHtmlTestCase
         $this->assertNotNull($entry, 'Expected a DiscussionForumPosting JSON-LD entry.');
         $this->assertSame('http://localhost/d/1-bake-bread', $entry['url'] ?? null);
         $this->assertSame('Person', $entry['author']['@type'] ?? null);
+        // A live author must carry a profile `url` — the field Google recommends
+        // and that satisfies Search Console.
+        $this->assertArrayHasKey('url', $entry['author']);
+        $this->assertNotEmpty($entry['author']['url']);
         $this->assertNotEmpty($entry['datePublished'] ?? null);
+    }
+
+    /**
+     * When the discussion starter has been deleted there is no profile page to
+     * link, so the `DiscussionForumPosting` `author` is omitted rather than
+     * emitted without a `url`. This is the exact field Search Console flagged:
+     * "Missing field 'url' (in 'author')". `author` is recommended, not
+     * required, so omission is valid (GH #140).
+     */
+    #[Test]
+    public function discussion_by_deleted_user_omits_the_author(): void
+    {
+        $this->prepareDatabase([
+            Discussion::class => [
+                // Started by a user that no longer exists (no row id 99).
+                ['id' => 1, 'title' => 'Orphaned discussion', 'slug' => 'orphaned', 'user_id' => 99, 'first_post_id' => 1, 'comment_count' => 1, 'created_at' => Carbon::now()],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 99, 'type' => 'comment', 'content' => '<t><p>The question.</p></t>', 'created_at' => Carbon::now()],
+            ],
+        ]);
+
+        $entry = $this->findSchemaEntry($this->fetchForumHtml('/d/1-orphaned'), 'DiscussionForumPosting');
+
+        $this->assertNotNull($entry, 'Expected a DiscussionForumPosting JSON-LD entry.');
+        $this->assertArrayNotHasKey('author', $entry);
     }
 
     /**


### PR DESCRIPTION
Google Search Console reported two non-critical structured data issues:

- Q&A: `Missing field 'url' (in 'mainEntity.author')`
- Discussion forum: `Missing field 'url' (in 'author')`

For a deleted user the schema emitted an `author` Person with a `name` but no `url`, because a deleted user has no profile page to link to. `author` is a recommended field, not required, so this omits the `author` object entirely for a deleted user instead of emitting an incomplete Person. Live authors are unchanged and keep their `name` and profile `url`.

Affects both `QAPage` (`DiscussionBestAnswerPage`) and `DiscussionForumPosting` (`DiscussionPage`), at the question/discussion author and per-answer/per-comment author levels.

Verified against a live forum: deleted authors omit `author`; live authors carry `url`.