### PR TITLE
[2.x] fix: lazy load modals for reduced js bundle size

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -33,7 +33,8 @@ return [
 
     (new Extend\Frontend('admin'))
       ->js(__DIR__.'/js/dist/admin.js')
-      ->css(__DIR__.'/less/Admin.less'),
+      ->css(__DIR__.'/less/Admin.less')
+      ->jsDirectory(__DIR__.'/js/dist/admin'),
 
     (new Extend\Frontend('common'))
       ->jsDirectory(__DIR__.'/js/dist/common'),

--- a/extend.php
+++ b/extend.php
@@ -35,6 +35,9 @@ return [
       ->js(__DIR__.'/js/dist/admin.js')
       ->css(__DIR__.'/less/Admin.less'),
 
+    (new Extend\Frontend('common'))
+      ->jsDirectory(__DIR__.'/js/dist/common'),
+
     (new Extend\Routes('api'))
       ->post('/seo_social_media_image', 'seo.socialmedia.upload', Api\Controllers\UploadSocialMediaImageController::class)
       ->delete('/seo_social_media_image', 'seo.socialmedia.delete', Api\Controllers\DeleteSocialMediaImageController::class)

--- a/js/src/admin/components/Forms/SeoSettings.tsx
+++ b/js/src/admin/components/Forms/SeoSettings.tsx
@@ -13,8 +13,6 @@ import ItemList from 'flarum/common/utils/ItemList';
 import extractText from 'flarum/common/utils/extractText';
 import type Mithril from 'mithril';
 
-import CrawlPostModal from '../Modals/CrawlPostModal';
-import DoFollowListModal from '../Modals/DoFollowListModal';
 import NoindexTagsSetting from './NoindexTagsSetting';
 import countKeywords from '../../utils/countKeywords';
 
@@ -154,7 +152,7 @@ export default class SeoSettings extends Component {
         className={this.showField !== 'all' && this.showField !== 'discussion-post' ? 'hidden' : ''}
       >
         <div className="helpText">{app.translator.trans('fof-seo.admin.settings.crawl.help')}</div>
-        <Button className="Button" onclick={() => app.modal.show(CrawlPostModal)}>
+        <Button className="Button" onclick={() => app.modal.show(() => import('../Modals/CrawlPostModal'))}>
           {app.translator.trans('fof-seo.admin.settings.crawl.button')}
         </Button>
       </FieldSet>,
@@ -196,7 +194,7 @@ export default class SeoSettings extends Component {
         </div>
         <div style="height: 5px;"></div>
         <div>
-          <Button className="Button" loading={this.saving} onclick={() => app.modal.show(DoFollowListModal)}>
+          <Button className="Button" loading={this.saving} onclick={() => app.modal.show(() => import('../Modals/DoFollowListModal'))}>
             {app.translator.trans('fof-seo.admin.settings.nofollow.button')}
           </Button>
         </div>

--- a/js/src/forum/index.tsx
+++ b/js/src/forum/index.tsx
@@ -2,7 +2,6 @@ import app from 'flarum/forum/app';
 import DiscussionControls from 'flarum/forum/utils/DiscussionControls';
 import Button from 'flarum/common/components/Button';
 import { extend } from 'flarum/common/extend';
-import MetaSeoModal from '../common/Components/MetaSeoModal';
 
 export { default as extend } from './extend';
 
@@ -15,7 +14,7 @@ app.initializers.add('fof-seo', () => {
       <Button
         icon="fas fa-search"
         onclick={() =>
-          app.modal.show(MetaSeoModal, {
+          app.modal.show(() => import('../common/Components/MetaSeoModal'), {
             objectType: 'discussions',
             objectId: discussion.id(),
           })


### PR DESCRIPTION
`MetaSeoModal` (~22KB) was eagerly imported into the forum entry, so it was bundled into the critical `forum.js` that every visitor downloads on every cold load. The modal is only reachable via the staff-only "Configure SEO" button (gated behind `canConfigureSeo`).

Pass an async importer to `app.modal.show` so webpack splits the modal into a chunk loaded on demand, and register the `common` JS directory in `extend.php` so Flarum serves that chunk. Production build: `forum.js` drops from ~22KB to ~6KB; the modal becomes a separate ~19KB chunk.

Also splits the admin modals for reduced admin js bundle size

Fixes #169