### PR TITLE
[2.x] Emit image/video on comment and Q&A nodes with no text

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     },
     "require-dev": {
         "flarum/likes": "*",
+        "flarum/markdown": "*",
         "fof/pages": "^2.0.0",
         "fof/best-answer": "^2.0.0",
         "fof/gamification": "*",
@@ -58,8 +59,10 @@
             "title": "FoF SEO",
             "category": "feature",
             "optional-dependencies": [
+                "flarum/markdown",
                 "fof/pages",
                 "fof/sitemap",
+                "fof/upload",
                 "fof/best-answer",
                 "fof/discussion-views",
                 "fof/discussion-language"

--- a/src/Page/DiscussionBestAnswerPage.php
+++ b/src/Page/DiscussionBestAnswerPage.php
@@ -25,6 +25,7 @@ use Flarum\User\User;
 use Flarum\User\UserRepository;
 use FoF\Seo\SeoMeta\SeoMeta;
 use FoF\Seo\SeoProperties;
+use FoF\Seo\Support\PostMedia;
 use FoF\Seo\TagIndexingPolicy;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
@@ -71,16 +72,6 @@ class DiscussionBestAnswerPage implements PageDriverInterface
             'name'  => $user->getDisplayNameAttribute(),
             'url'   => $this->urlGenerator->to('forum')->route('user', ['username' => $this->slugManager->forResource(User::class)->toSlug($user)]),
         ];
-    }
-
-    /**
-     * Render a post's stored content to plain text for a schema `text` field:
-     * render to HTML so mentions/links resolve, then decode entities and strip
-     * tags. Mirrors the DiscussionForumPosting comment handling (PR #141).
-     */
-    private function plainText(CommentPost $post): string
-    {
-        return trim(html_entity_decode(strip_tags($post->formatContent()), ENT_QUOTES | ENT_HTML5));
     }
 
     public function extensionDependencies(): array
@@ -189,10 +180,16 @@ class DiscussionBestAnswerPage implements PageDriverInterface
         $mainEntity = [
             '@type'       => 'Question',
             'name'        => $seoMeta->title,
-            'text'        => $firstPost instanceof CommentPost ? $this->plainText($firstPost) : '',
             'dateCreated' => $seoMeta->created_at,
             'answerCount' => $discussion->comment_count - 1,
         ];
+
+        // text/image/video for the question (its first post). Google's "Either
+        // 'text', 'image' or 'video' should be specified" applies here too, so
+        // emit whichever the post actually has rather than an empty `text`.
+        if ($firstPost instanceof CommentPost) {
+            $mainEntity += PostMedia::schemaFields($firstPost->formatContent());
+        }
 
         // Omit `author` when the starter is deleted — see authorSchema().
         if (($questionAuthor = $this->authorSchema($discussion->user)) !== null) {
@@ -244,13 +241,14 @@ class DiscussionBestAnswerPage implements PageDriverInterface
                 continue;
             }
 
-            // Temp post
+            // Temp post. text/image/video from the rendered HTML so an
+            // image-only answer carries `image` instead of an empty `text`
+            // (Google's "Either 'text', 'image' or 'video'" rule).
             $generatedPost = [
                 '@type'       => 'Answer',
-                'text'        => $this->plainText($post),
                 'dateCreated' => $post->created_at->toIso8601String(),
                 'url'         => $this->urlGenerator->to('forum')->route('discussion', ['id' => $discussion->id.'-'.$discussion->slug, 'near' => $post->number]),
-            ];
+            ] + PostMedia::schemaFields($post->formatContent());
 
             // Omit `author` when this post's user is deleted — see authorSchema().
             if (($answerAuthor = $this->authorSchema($post->user)) !== null) {

--- a/src/Page/DiscussionPage.php
+++ b/src/Page/DiscussionPage.php
@@ -12,6 +12,7 @@
 namespace FoF\Seo\Page;
 
 use Flarum\Database\Eloquent\Collection;
+use Flarum\Discussion\Discussion as FlarumDiscussion;
 use Flarum\Discussion\DiscussionRepository;
 use Flarum\Extension\ExtensionManager;
 use Flarum\Foundation\DispatchEventsTrait;
@@ -25,6 +26,7 @@ use Flarum\User\User;
 use Flarum\User\UserRepository;
 use FoF\Seo\SeoMeta\SeoMeta;
 use FoF\Seo\SeoProperties;
+use FoF\Seo\Support\PostMedia;
 use FoF\Seo\TagIndexingPolicy;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
@@ -71,6 +73,64 @@ class DiscussionPage implements PageDriverInterface
             'name'  => $user->getDisplayNameAttribute(),
             'url'   => $this->urlGenerator->to('forum')->route('user', ['username' => $this->slugManager->forResource(User::class)->toSlug($user)]),
         ];
+    }
+
+    /**
+     * Build a schema.org Comment node for a reply, or null when the reply has
+     * none of the content a Comment requires. Google's forum guidance says a
+     * `comment` must specify at least one of `text`, `image` or `video`; a
+     * reply that is e.g. an image with no caption otherwise produced an empty
+     * `text`, tripping Search Console's "Either 'text', 'image' or 'video'
+     * should be specified (in 'comment')". We emit `text` when there is any,
+     * plus any images/videos found in the rendered HTML, and omit the comment
+     * entirely when it has none of the three.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function commentSchema(CommentPost $post, FlarumDiscussion $discussion, bool $enableLikes, bool $enableGamification): ?array
+    {
+        // Render once and pull text/image/video from the same HTML so any
+        // extension's final URLs (e.g. fof/upload's image preview) are
+        // reflected. Google requires a Comment to specify at least one of them.
+        $media = PostMedia::schemaFields($post->formatContent());
+
+        if ($media === []) {
+            return null;
+        }
+
+        $comment = [
+            '@type'         => 'Comment',
+            // Google requires `datePublished` on Comment nodes; keep
+            // `dateCreated` too for schema.org completeness.
+            'datePublished' => $post->created_at->toIso8601String(),
+            'dateCreated'   => $post->created_at->toIso8601String(),
+            'url'           => $this->urlGenerator->to('forum')->route('discussion', ['id' => $discussion->id.'-'.$discussion->slug, 'near' => $post->number]),
+        ] + $media;
+
+        // Omit `author` when the commenter is deleted — see authorSchema().
+        if (($commentAuthor = $this->authorSchema($post->user)) !== null) {
+            $comment['author'] = $commentAuthor;
+        }
+
+        if ($enableLikes || $enableGamification) {
+            $count = 0;
+
+            if ($enableLikes) {
+                $count += (int) $post->getAttribute('likes_count');
+            }
+
+            if ($enableGamification) {
+                $count += (int) $post->getAttribute('upvotes_count');
+            }
+
+            $comment['interactionStatistic'] = [
+                '@type'                => 'InteractionCounter',
+                'interactionType'      => 'https://schema.org/LikeAction',
+                'userInteractionCount' => $count,
+            ];
+        }
+
+        return $comment;
     }
 
     public function extensionDependencies(): array
@@ -248,44 +308,14 @@ class DiscussionPage implements PageDriverInterface
             /** @var Collection<int, Post> $replies */
             $replies = $query->get();
 
-            $comments = $replies->filter(fn (Post $post) => $post instanceof CommentPost)->map(function (CommentPost $post) use ($discussion, $enableLikes, $enableGamification) {
-                $comment = [
-                    '@type'         => 'Comment',
-                    // Render to HTML so mentions/links resolve, then decode
-                    // entities and strip tags for clean plain text.
-                    'text'          => trim(html_entity_decode(strip_tags($post->formatContent()), ENT_QUOTES | ENT_HTML5)),
-                    // Google requires `datePublished` on Comment nodes; keep
-                    // `dateCreated` too for schema.org completeness.
-                    'datePublished' => $post->created_at->toIso8601String(),
-                    'dateCreated'   => $post->created_at->toIso8601String(),
-                    'url'           => $this->urlGenerator->to('forum')->route('discussion', ['id' => $discussion->id.'-'.$discussion->slug, 'near' => $post->number]),
-                ];
-
-                // Omit `author` when the commenter is deleted — see authorSchema().
-                if (($commentAuthor = $this->authorSchema($post->user)) !== null) {
-                    $comment['author'] = $commentAuthor;
-                }
-
-                if ($enableLikes || $enableGamification) {
-                    $count = 0;
-
-                    if ($enableLikes) {
-                        $count += (int) $post->getAttribute('likes_count');
-                    }
-
-                    if ($enableGamification) {
-                        $count += (int) $post->getAttribute('upvotes_count');
-                    }
-
-                    $comment['interactionStatistic'] = [
-                        '@type'                => 'InteractionCounter',
-                        'interactionType'      => 'https://schema.org/LikeAction',
-                        'userInteractionCount' => $count,
-                    ];
-                }
-
-                return $comment;
-            })->values()->toArray();
+            $comments = $replies
+                ->filter(fn (Post $post) => $post instanceof CommentPost)
+                // commentSchema() returns null for a reply with no text/image —
+                // such a comment node would be invalid, so drop it entirely.
+                ->map(fn (CommentPost $post) => $this->commentSchema($post, $discussion, $enableLikes, $enableGamification))
+                ->filter()
+                ->values()
+                ->toArray();
 
             if (count($comments) > 0) {
                 $properties->setSchemaJson('comment', $comments);

--- a/src/Support/PostMedia.php
+++ b/src/Support/PostMedia.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of fof/seo.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Seo\Support;
+
+/**
+ * Pull media URLs out of rendered post HTML. s9e/TextFormatter renders every
+ * media source to a standard HTML tag, so a single `src` match per tag type
+ * covers every plugin/extension:
+ *
+ *  - images:  markdown / Autoimage / fof/upload image-preview → `<img src>`
+ *  - videos:  Autovideo (mp4/webm/…)                          → `<video src>`
+ *
+ * MediaEmbed `<iframe>` embeds (YouTube, Vimeo, …) are deliberately ignored:
+ * a schema.org VideoObject built from an embed URL alone lacks the name,
+ * thumbnail and uploadDate Google expects and would invite its own warnings.
+ */
+class PostMedia
+{
+    /**
+     * Plain text rendered from post HTML: decode entities and strip tags so
+     * mentions/links reduce to their visible label. The schema `text` field.
+     */
+    public static function text(string $html): string
+    {
+        return trim(html_entity_decode(strip_tags($html), ENT_QUOTES | ENT_HTML5));
+    }
+
+    /**
+     * Build the schema.org content fields for a post's rendered HTML — `text`,
+     * `image` and/or `video` — so a Comment/Question/Answer node always carries
+     * at least one of the three Google requires (when the post has any content
+     * at all). `image` is a string for a single image or a list for several;
+     * `video` is a VideoObject (or a list of them) carrying the `contentUrl`.
+     *
+     * Returns only the keys that are present, so callers can merge the result
+     * straight into their node and check `=== []` to detect an empty post.
+     *
+     * @return array{text?: string, image?: string|list<string>, video?: array<string, string>|list<array<string, string>>}
+     */
+    public static function schemaFields(string $html): array
+    {
+        $fields = [];
+
+        if (($text = self::text($html)) !== '') {
+            $fields['text'] = $text;
+        }
+
+        $images = self::images($html);
+
+        if ($images !== []) {
+            // A single image as a string, multiple as a list — both valid.
+            $fields['image'] = count($images) === 1 ? $images[0] : $images;
+        }
+
+        $videos = self::videos($html);
+
+        if ($videos !== []) {
+            // schema.org `video` expects a VideoObject; a bare `<video src>`
+            // gives us the contentUrl.
+            $objects = array_map(fn (string $url) => [
+                '@type'      => 'VideoObject',
+                'contentUrl' => $url,
+            ], $videos);
+
+            $fields['video'] = count($objects) === 1 ? $objects[0] : $objects;
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Image URLs from `<img src="…">`, in document order, de-duplicated, with
+     * HTML entities decoded.
+     *
+     * @return list<string>
+     */
+    public static function images(string $html): array
+    {
+        return self::srcUrls('img', $html);
+    }
+
+    /**
+     * Video file URLs from `<video src="…">`, in document order, de-duplicated,
+     * with HTML entities decoded.
+     *
+     * @return list<string>
+     */
+    public static function videos(string $html): array
+    {
+        return self::srcUrls('video', $html);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function srcUrls(string $tag, string $html): array
+    {
+        if (!str_contains($html, '<'.$tag)) {
+            return [];
+        }
+
+        preg_match_all('/<'.$tag.'\b[^>]*?\bsrc=("|\')(.*?)\1/i', $html, $matches);
+
+        $urls = [];
+
+        foreach ($matches[2] as $url) {
+            $url = html_entity_decode($url, ENT_QUOTES | ENT_HTML5);
+
+            if ($url !== '' && !in_array($url, $urls, true)) {
+                $urls[] = $url;
+            }
+        }
+
+        return $urls;
+    }
+}

--- a/tests/integration/forum/BestAnswerPageTest.php
+++ b/tests/integration/forum/BestAnswerPageTest.php
@@ -318,6 +318,84 @@ class BestAnswerPageTest extends ForumHtmlTestCase
     }
 
     /**
+     * Google's "Either 'text', 'image' or 'video' should be specified" applies
+     * to QAPage Question/Answer nodes too. An image-only accepted answer must
+     * carry `image` rather than an empty `text`.
+     */
+    #[Test]
+    public function image_only_answer_emits_image_and_no_empty_text(): void
+    {
+        $this->extension('flarum-markdown');
+        $this->setting('seo_post_crawler', '1');
+
+        $now = Carbon::now();
+
+        $this->prepareDatabase([
+            Tag::class => [
+                ['id' => self::QNA_TAG_ID, 'name' => 'Questions', 'slug' => 'questions', 'description' => null, 'color' => '#000', 'position' => 0, 'is_restricted' => false, 'is_hidden' => false, 'is_qna' => true],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'How do I bake bread?', 'slug' => 'how-do-i-bake-bread', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 2, 'best_answer_post_id' => 2, 'created_at' => $now, 'last_posted_at' => $now],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>How?</p></t>', 'created_at' => $now],
+                // Accepted answer that is only an image, no caption.
+                ['id' => 2, 'discussion_id' => 1, 'number' => 2, 'user_id' => 1, 'type' => 'comment', 'content' => '<r><p><IMG alt="" src="https://example.com/loaf.png"><s>![</s><e>](https://example.com/loaf.png)</e></IMG></p></r>', 'created_at' => $now],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => self::QNA_TAG_ID],
+            ],
+        ]);
+
+        $accepted = $this->findSchemaEntry($this->fetchForumHtml('/d/1-how-do-i-bake-bread'), 'QAPage')['mainEntity']['acceptedAnswer'] ?? [];
+
+        $this->assertSame('Answer', $accepted['@type'] ?? null);
+        // No empty `text`; the image is emitted instead.
+        $this->assertArrayNotHasKey('text', $accepted);
+        $this->assertSame('https://example.com/loaf.png', $accepted['image'] ?? null);
+    }
+
+    /**
+     * The same rule applies to the Question node: an image-only first post
+     * emits `image` (alongside the always-present `name`/title) rather than an
+     * empty `text`.
+     */
+    #[Test]
+    public function image_only_question_emits_image_and_no_empty_text(): void
+    {
+        $this->extension('flarum-markdown');
+        $this->setting('seo_post_crawler', '1');
+
+        $now = Carbon::now();
+
+        $this->prepareDatabase([
+            Tag::class => [
+                ['id' => self::QNA_TAG_ID, 'name' => 'Questions', 'slug' => 'questions', 'description' => null, 'color' => '#000', 'position' => 0, 'is_restricted' => false, 'is_hidden' => false, 'is_qna' => true],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'Spot the difference', 'slug' => 'spot-the-difference', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 2, 'best_answer_post_id' => 2, 'created_at' => $now, 'last_posted_at' => $now],
+            ],
+            Post::class => [
+                // First post (the question) is only an image.
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<r><p><IMG alt="" src="https://example.com/q.png"><s>![</s><e>](https://example.com/q.png)</e></IMG></p></r>', 'created_at' => $now],
+                ['id' => 2, 'discussion_id' => 1, 'number' => 2, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>It is the left one.</p></t>', 'created_at' => $now],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => self::QNA_TAG_ID],
+            ],
+        ]);
+
+        $question = $this->findSchemaEntry($this->fetchForumHtml('/d/1-spot-the-difference'), 'QAPage')['mainEntity'] ?? [];
+
+        $this->assertSame('Question', $question['@type'] ?? null);
+        // The title is always present as `name`...
+        $this->assertSame('Spot the difference', $question['name'] ?? null);
+        // ...and the image stands in for the absent text.
+        $this->assertArrayNotHasKey('text', $question);
+        $this->assertSame('https://example.com/q.png', $question['image'] ?? null);
+    }
+
+    /**
      * The optional flarum/likes integration: when it's enabled, an answer's
      * `upvoteCount` reflects its like count.
      */

--- a/tests/integration/forum/DiscussionCommentsTest.php
+++ b/tests/integration/forum/DiscussionCommentsTest.php
@@ -37,6 +37,19 @@ class DiscussionCommentsTest extends ForumHtmlTestCase
         $this->setting('seo_post_crawler', '1');
     }
 
+    /**
+     * The stored TextFormatter XML fof/upload produces for an uploaded image,
+     * which its image-preview formatter renders to an `<img src={thumbnail}>`.
+     */
+    private function imagePreviewMarkup(string $url, string $thumbnailUrl, string $alt): string
+    {
+        $uuid = '00000000-0000-0000-0000-000000000000';
+
+        return '<p><UPL-IMAGE-PREVIEW alt="'.$alt.'" thumbnail_url="'.$thumbnailUrl.'" url="'.$url.'" uuid="'.$uuid.'">'
+            .'[upl-image-preview uuid='.$uuid.' url='.$url.' alt='.$alt.' thumbnail_url='.$thumbnailUrl.']'
+            .'</UPL-IMAGE-PREVIEW></p>';
+    }
+
     private function seedThread(): void
     {
         $this->prepareDatabase([
@@ -181,6 +194,137 @@ class DiscussionCommentsTest extends ForumHtmlTestCase
         $this->assertStringNotContainsString('URL', $text);
         $this->assertStringNotContainsString('https://example.com', $text);
         $this->assertStringNotContainsString('&amp;', $text);
+    }
+
+    /**
+     * Google's forum guidance requires a `comment` to specify at least one of
+     * `text`, `image` or `video`. A reply that is only an image has no plain
+     * text, so instead of emitting an empty `text` (which trips Search
+     * Console's "Either 'text', 'image' or 'video' should be specified") we
+     * emit the rendered image URL as `image` and omit `text`.
+     *
+     * Rendered end-to-end through fof/upload's image-preview formatter, which
+     * (like every image source) produces a standard `<img src>` we extract —
+     * exercising the real render → extract → schema path.
+     */
+    #[Test]
+    public function image_only_comment_emits_image_and_no_empty_text(): void
+    {
+        $this->extension('fof-upload');
+
+        $this->prepareDatabase([
+            User::class => [
+                ['id' => 2, 'username' => 'alice', 'email' => 'a@example.com', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'is_email_confirmed' => 1],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'How do I bake bread', 'slug' => 'bake-bread', 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 2, 'created_at' => Carbon::now()],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>The question.</p></t>', 'created_at' => Carbon::now()],
+                // Reply that is only an uploaded image, no caption.
+                ['id' => 2, 'discussion_id' => 1, 'number' => 2, 'user_id' => 2, 'type' => 'comment', 'content' => '<r>'.$this->imagePreviewMarkup('https://example.com/bread.png', 'https://example.com/bread-thumb.webp', 'bread.png').'</r>', 'created_at' => Carbon::now()],
+            ],
+        ]);
+
+        $comment = $this->findSchemaEntry($this->fetchForumHtml('/d/1-bake-bread'), 'DiscussionForumPosting')['comment'][0] ?? null;
+
+        $this->assertIsArray($comment);
+        $this->assertSame('Comment', $comment['@type'] ?? null);
+        // No empty `text` field.
+        $this->assertArrayNotHasKey('text', $comment);
+        // The rendered image (the thumbnail src fof/upload emits) is present.
+        $this->assertSame('https://example.com/bread-thumb.webp', $comment['image'] ?? null);
+    }
+
+    /**
+     * A reply that contains both text and an image keeps its `text` and also
+     * exposes the `image`.
+     */
+    #[Test]
+    public function comment_with_text_and_image_emits_both(): void
+    {
+        $this->extension('fof-upload');
+
+        $this->prepareDatabase([
+            User::class => [
+                ['id' => 2, 'username' => 'alice', 'email' => 'a@example.com', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'is_email_confirmed' => 1],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'How do I bake bread', 'slug' => 'bake-bread', 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 2, 'created_at' => Carbon::now()],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>The question.</p></t>', 'created_at' => Carbon::now()],
+                ['id' => 2, 'discussion_id' => 1, 'number' => 2, 'user_id' => 2, 'type' => 'comment', 'content' => '<r><p>Here is my loaf</p>'.$this->imagePreviewMarkup('https://example.com/loaf.png', 'https://example.com/loaf-thumb.webp', 'loaf.png').'</r>', 'created_at' => Carbon::now()],
+            ],
+        ]);
+
+        $comment = $this->findSchemaEntry($this->fetchForumHtml('/d/1-bake-bread'), 'DiscussionForumPosting')['comment'][0] ?? null;
+
+        $this->assertIsArray($comment);
+        $this->assertStringContainsString('Here is my loaf', $comment['text'] ?? '');
+        $this->assertSame('https://example.com/loaf-thumb.webp', $comment['image'] ?? null);
+    }
+
+    /**
+     * Image extraction is not fof/upload-specific: a plain markdown image
+     * (rendered by flarum/markdown to a standard `<img>`) is picked up the same
+     * way. Locks in that the source is the rendered HTML, not any one plugin.
+     */
+    #[Test]
+    public function markdown_image_only_comment_emits_image(): void
+    {
+        $this->extension('flarum-markdown');
+
+        $this->prepareDatabase([
+            User::class => [
+                ['id' => 2, 'username' => 'alice', 'email' => 'a@example.com', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'is_email_confirmed' => 1],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'How do I bake bread', 'slug' => 'bake-bread', 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 2, 'created_at' => Carbon::now()],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>The question.</p></t>', 'created_at' => Carbon::now()],
+                // Stored markdown-image XML, as flarum/markdown parses `![](url)`.
+                ['id' => 2, 'discussion_id' => 1, 'number' => 2, 'user_id' => 2, 'type' => 'comment', 'content' => '<r><p><IMG alt="" src="https://example.com/md.png"><s>![</s><e>](https://example.com/md.png)</e></IMG></p></r>', 'created_at' => Carbon::now()],
+            ],
+        ]);
+
+        $comment = $this->findSchemaEntry($this->fetchForumHtml('/d/1-bake-bread'), 'DiscussionForumPosting')['comment'][0] ?? null;
+
+        $this->assertIsArray($comment);
+        $this->assertArrayNotHasKey('text', $comment);
+        $this->assertSame('https://example.com/md.png', $comment['image'] ?? null);
+    }
+
+    /**
+     * A reply with neither plain text nor any image cannot form a valid
+     * `comment` node, so it is omitted entirely rather than emitted with an
+     * empty `text`.
+     */
+    #[Test]
+    public function comment_with_neither_text_nor_image_is_omitted(): void
+    {
+        $this->prepareDatabase([
+            User::class => [
+                ['id' => 2, 'username' => 'alice', 'email' => 'a@example.com', 'password' => '$2y$10$LO59tiT7uggl6Oe23o/O6.utnF6ipngYjvMvaxo1TciKqBttDNKim', 'is_email_confirmed' => 1],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'How do I bake bread', 'slug' => 'bake-bread', 'user_id' => 2, 'first_post_id' => 1, 'comment_count' => 3, 'created_at' => Carbon::now()],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>The question.</p></t>', 'created_at' => Carbon::now()],
+                // Reply that renders to nothing (whitespace only).
+                ['id' => 2, 'discussion_id' => 1, 'number' => 2, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p> </p></t>', 'created_at' => Carbon::now()],
+                // A normal reply, so the comment[] block is still emitted.
+                ['id' => 3, 'discussion_id' => 1, 'number' => 3, 'user_id' => 2, 'type' => 'comment', 'content' => '<t><p>A real reply.</p></t>', 'created_at' => Carbon::now()],
+            ],
+        ]);
+
+        $comments = $this->findSchemaEntry($this->fetchForumHtml('/d/1-bake-bread'), 'DiscussionForumPosting')['comment'] ?? [];
+
+        // The empty reply (post 2) is dropped; only the real reply remains.
+        $this->assertCount(1, $comments);
+        $this->assertStringContainsString('A real reply.', $comments[0]['text'] ?? '');
     }
 
     #[Test]

--- a/tests/unit/Support/PostMediaTest.php
+++ b/tests/unit/Support/PostMediaTest.php
@@ -1,0 +1,148 @@
+<?php
+
+/*
+ * This file is part of fof/seo.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Seo\Tests\unit\Support;
+
+use FoF\Seo\Support\PostMedia;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class PostMediaTest extends TestCase
+{
+    #[Test]
+    public function returns_empty_for_html_without_media(): void
+    {
+        $this->assertSame([], PostMedia::images('<p>Just some text.</p>'));
+        $this->assertSame([], PostMedia::videos('<p>Just some text.</p>'));
+        $this->assertSame([], PostMedia::images(''));
+    }
+
+    #[Test]
+    public function extracts_a_plain_image(): void
+    {
+        $html = '<p>text and an <img src="https://example.com/a.png" alt=""></p>';
+
+        $this->assertSame(['https://example.com/a.png'], PostMedia::images($html));
+    }
+
+    #[Test]
+    public function extracts_a_fof_upload_image_preview(): void
+    {
+        // The shape fof/upload's image-preview template renders to (the <img>
+        // is wrapped in a link, and the src is the thumbnail).
+        $html = '<a href="https://forum.tld/f/x.png" class="FoFUpload--Upl-Image-Preview-Link"><img class="FoFUpload--Upl-Image-Preview" src="https://forum.tld/f/x-thumb.webp" alt="x.png" loading="lazy" width="800" height="800"/></a>';
+
+        $this->assertSame(['https://forum.tld/f/x-thumb.webp'], PostMedia::images($html));
+    }
+
+    #[Test]
+    public function decodes_html_entities_in_the_url(): void
+    {
+        // External images frequently carry `&amp;`-encoded query strings.
+        $html = '<img src="https://img.tld/i.png?width=600&amp;height=600&amp;id=1">';
+
+        $this->assertSame(['https://img.tld/i.png?width=600&height=600&id=1'], PostMedia::images($html));
+    }
+
+    #[Test]
+    public function collects_multiple_images_in_order_and_deduplicates(): void
+    {
+        $html = '<img src="https://a.tld/1.png"><img src="https://a.tld/2.png"><img src="https://a.tld/1.png">';
+
+        $this->assertSame(
+            ['https://a.tld/1.png', 'https://a.tld/2.png'],
+            PostMedia::images($html)
+        );
+    }
+
+    #[Test]
+    public function handles_single_quoted_src_attributes(): void
+    {
+        $html = "<img src='https://a.tld/q.png'>";
+
+        $this->assertSame(['https://a.tld/q.png'], PostMedia::images($html));
+    }
+
+    #[Test]
+    public function extracts_a_video_source(): void
+    {
+        // The shape s9e Autovideo renders to.
+        $html = '<video controls="" src="https://a.tld/clip.mp4"></video>';
+
+        $this->assertSame(['https://a.tld/clip.mp4'], PostMedia::videos($html));
+        // A <video> is not an image.
+        $this->assertSame([], PostMedia::images($html));
+    }
+
+    #[Test]
+    public function schema_fields_are_empty_for_a_blank_post(): void
+    {
+        $this->assertSame([], PostMedia::schemaFields('<p></p>'));
+        $this->assertSame([], PostMedia::schemaFields(''));
+    }
+
+    #[Test]
+    public function schema_fields_emit_text_only(): void
+    {
+        $this->assertSame(['text' => 'Hello there'], PostMedia::schemaFields('<p>Hello there</p>'));
+    }
+
+    #[Test]
+    public function schema_fields_emit_a_single_image_as_a_string(): void
+    {
+        $fields = PostMedia::schemaFields('<p>look <img src="https://a.tld/1.png"></p>');
+
+        $this->assertSame('look', $fields['text'] ?? null);
+        $this->assertSame('https://a.tld/1.png', $fields['image'] ?? null);
+    }
+
+    #[Test]
+    public function schema_fields_emit_multiple_images_as_a_list(): void
+    {
+        $fields = PostMedia::schemaFields('<img src="https://a.tld/1.png"><img src="https://a.tld/2.png">');
+
+        $this->assertArrayNotHasKey('text', $fields);
+        $this->assertSame(['https://a.tld/1.png', 'https://a.tld/2.png'], $fields['image'] ?? null);
+    }
+
+    #[Test]
+    public function schema_fields_wrap_a_single_video_as_a_video_object(): void
+    {
+        $fields = PostMedia::schemaFields('<video controls="" src="https://a.tld/clip.mp4"></video>');
+
+        $this->assertArrayNotHasKey('text', $fields);
+        $this->assertSame([
+            '@type'      => 'VideoObject',
+            'contentUrl' => 'https://a.tld/clip.mp4',
+        ], $fields['video'] ?? null);
+    }
+
+    #[Test]
+    public function schema_fields_wrap_multiple_videos_as_a_list_of_video_objects(): void
+    {
+        $fields = PostMedia::schemaFields('<video src="https://a.tld/1.mp4"></video><video src="https://a.tld/2.mp4"></video>');
+
+        $this->assertSame([
+            ['@type' => 'VideoObject', 'contentUrl' => 'https://a.tld/1.mp4'],
+            ['@type' => 'VideoObject', 'contentUrl' => 'https://a.tld/2.mp4'],
+        ], $fields['video'] ?? null);
+    }
+
+    #[Test]
+    public function schema_fields_combine_text_image_and_video(): void
+    {
+        $fields = PostMedia::schemaFields('<p>caption</p><img src="https://a.tld/i.png"><video src="https://a.tld/v.mp4"></video>');
+
+        $this->assertSame('caption', $fields['text'] ?? null);
+        $this->assertSame('https://a.tld/i.png', $fields['image'] ?? null);
+        $this->assertSame(['@type' => 'VideoObject', 'contentUrl' => 'https://a.tld/v.mp4'], $fields['video'] ?? null);
+    }
+}


### PR DESCRIPTION
Search Console reported, on both schemas:

- Discussion forum: `Either 'text', 'image' or 'video' should be specified (in 'comment')`
- Q&A: the same, on Question/Answer nodes

A reply or answer that is only an image (or video) rendered to a node with an empty `text` and no other content, satisfying none of the required-one-of `text`/`image`/`video`.

Extract images (`<img src>`) and videos (`<video src>`) from the rendered post HTML — covering markdown, s9e Autoimage/Autovideo and fof/upload's image preview — and emit them as `image` / `video` (a `VideoObject` with `contentUrl`) alongside any `text`. A `DiscussionForumPosting` comment with none of the three is omitted entirely rather than emitted invalid; QAPage Question/Answer nodes keep their structure (the Question always has its title as `name`).

Shared extraction lives in `FoF\Seo\Support\PostMedia`, used by both page drivers. MediaEmbed `<iframe>` embeds (YouTube/Vimeo) are deliberately not mapped, since a VideoObject built from an embed URL alone lacks the name/thumbnail/uploadDate Google expects.

`flarum/markdown` added as a dev/optional dependency so the markdown image path is tested through the real render pipeline.

Verified on a live forum: image-only and text+image comments emit `image` with no empty `text`; text answers/questions unchanged.