### PR TITLE
[2.x] feat: Rich, hierarchical, extensible breadcrumbs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "flarum/phpstan": "^2.0.0",
         "flarum/testing": "^2.0.0",
         "fof/discussion-views": "*",
-        "fof/upload": "*"
+        "fof/upload": "*",
+        "fof/user-directory": "*"
     },
     "conflict": {
         "zerosonesfun/elint": "*",
@@ -65,7 +66,8 @@
                 "fof/upload",
                 "fof/best-answer",
                 "fof/discussion-views",
-                "fof/discussion-language"
+                "fof/discussion-language",
+                "fof/user-directory"
             ],
             "icon": {
                 "name": "fas fa-check",

--- a/extend.php
+++ b/extend.php
@@ -101,7 +101,8 @@ return [
             ->subscribe(Subscribers\TagSubscriber::class),
 
           (new SEO())
-            ->addExtender('tag', SeoPage\TagPage::class),
+            ->addExtender('tag', SeoPage\TagPage::class)
+            ->addExtender('tags', SeoPage\TagsPage::class),
       ])
       ->whenExtensionEnabled('fof-best-answer', fn () => [
           (new SEO())
@@ -110,5 +111,9 @@ return [
       ->whenExtensionEnabled('fof-pages', fn () => [
           (new SEO())
             ->addExtender('page_extension', SeoPage\PageExtensionPage::class),
+      ])
+      ->whenExtensionEnabled('fof-user-directory', fn () => [
+          (new SEO())
+            ->addExtender('fof_user_directory', SeoPage\UserDirectoryPage::class),
       ]),
 ];

--- a/src/Breadcrumb/BreadcrumbTrail.php
+++ b/src/Breadcrumb/BreadcrumbTrail.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * This file is part of fof/seo.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Seo\Breadcrumb;
+
+/**
+ * A mutable, ordered breadcrumb trail. Page drivers build it up and third
+ * parties reshape it (via the BuildingBreadcrumb event) before it is rendered
+ * to a schema.org BreadcrumbList.
+ */
+class BreadcrumbTrail
+{
+    /** @var list<Crumb> */
+    protected array $crumbs = [];
+
+    /**
+     * Append a crumb to the end of the trail.
+     */
+    public function push(Crumb $crumb): self
+    {
+        $this->crumbs[] = $crumb;
+
+        return $this;
+    }
+
+    /**
+     * Prepend a crumb to the start of the trail (e.g. a "Home" root).
+     */
+    public function prepend(Crumb $crumb): self
+    {
+        array_unshift($this->crumbs, $crumb);
+
+        return $this;
+    }
+
+    /**
+     * Insert a crumb immediately after the first existing crumb matching the
+     * predicate. If none match, the crumb is appended.
+     *
+     * @param callable(Crumb): bool $predicate
+     */
+    public function insertAfter(callable $predicate, Crumb $crumb): self
+    {
+        foreach ($this->crumbs as $index => $existing) {
+            if ($predicate($existing)) {
+                array_splice($this->crumbs, $index + 1, 0, [$crumb]);
+
+                return $this;
+            }
+        }
+
+        return $this->push($crumb);
+    }
+
+    /**
+     * Remove every crumb matching the predicate.
+     *
+     * @param callable(Crumb): bool $predicate
+     */
+    public function remove(callable $predicate): self
+    {
+        $this->crumbs = array_values(array_filter(
+            $this->crumbs,
+            fn (Crumb $crumb) => !$predicate($crumb)
+        ));
+
+        return $this;
+    }
+
+    /**
+     * Replace each crumb with the result of the callback. Returning the same
+     * crumb (mutated) is fine; returning a new Crumb replaces it.
+     *
+     * @param callable(Crumb): Crumb $callback
+     */
+    public function map(callable $callback): self
+    {
+        $this->crumbs = array_values(array_map($callback, $this->crumbs));
+
+        return $this;
+    }
+
+    /**
+     * Replace the whole trail.
+     *
+     * @param list<Crumb> $crumbs
+     */
+    public function set(array $crumbs): self
+    {
+        $this->crumbs = array_values($crumbs);
+
+        return $this;
+    }
+
+    /**
+     * @return list<Crumb>
+     */
+    public function all(): array
+    {
+        return $this->crumbs;
+    }
+
+    public function count(): int
+    {
+        return count($this->crumbs);
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->crumbs === [];
+    }
+
+    /**
+     * Render to a schema.org BreadcrumbList, or null when there are fewer than
+     * two crumbs — Google requires at least two items, and a single crumb is
+     * not a trail.
+     *
+     * Per Google's guidance the last item's `item` is omitted (Google uses the
+     * containing page's URL); `itemListOrder`/`numberOfItems` are not emitted as
+     * they are not required and the order is already conveyed by `position`.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function toSchema(): ?array
+    {
+        if (count($this->crumbs) < 2) {
+            return null;
+        }
+
+        $elements = [];
+        $last = count($this->crumbs) - 1;
+
+        foreach ($this->crumbs as $index => $crumb) {
+            $element = [
+                '@type'    => 'ListItem',
+                'position' => $index + 1,
+                'name'     => $crumb->name,
+            ];
+
+            // The current page (last crumb, or any crumb without a url) omits
+            // `item`; Google falls back to the page URL.
+            if ($crumb->url !== null && $index !== $last) {
+                $element['item'] = array_merge([
+                    '@type' => $crumb->type,
+                    '@id'   => $crumb->url,
+                    'name'  => $crumb->name,
+                    'url'   => $crumb->url,
+                ], $crumb->extra);
+            }
+
+            $elements[] = $element;
+        }
+
+        return [
+            '@context'        => 'https://schema.org',
+            '@type'           => 'BreadcrumbList',
+            'itemListElement' => $elements,
+        ];
+    }
+}

--- a/src/Breadcrumb/Crumb.php
+++ b/src/Breadcrumb/Crumb.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of fof/seo.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Seo\Breadcrumb;
+
+/**
+ * A single step in a breadcrumb trail.
+ *
+ * `url` is optional: a crumb with no url represents the current page (it should
+ * be the last in the trail), for which Google uses the page's own URL.
+ */
+class Crumb
+{
+    /**
+     * @param array<string, mixed> $extra extra properties merged into the
+     *                                     schema.org `item` object (e.g. an
+     *                                     explicit `@id` or `image`)
+     */
+    public function __construct(
+        public string $name,
+        public ?string $url = null,
+        public string $type = 'WebPage',
+        public array $extra = [],
+    ) {
+    }
+}

--- a/src/Breadcrumb/Crumb.php
+++ b/src/Breadcrumb/Crumb.php
@@ -21,8 +21,8 @@ class Crumb
 {
     /**
      * @param array<string, mixed> $extra extra properties merged into the
-     *                                     schema.org `item` object (e.g. an
-     *                                     explicit `@id` or `image`)
+     *                                    schema.org `item` object (e.g. an
+     *                                    explicit `@id` or `image`)
      */
     public function __construct(
         public string $name,

--- a/src/Breadcrumb/TagBreadcrumb.php
+++ b/src/Breadcrumb/TagBreadcrumb.php
@@ -1,0 +1,162 @@
+<?php
+
+/*
+ * This file is part of fof/seo.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Seo\Breadcrumb;
+
+use Flarum\Http\UrlGenerator;
+use Flarum\Tags\Tag;
+use FoF\Seo\SeoProperties;
+use Illuminate\Support\Collection;
+
+/**
+ * Builds the tag-hierarchy portion of breadcrumb trails.
+ *
+ * Only *primary* tags form a breadcrumb path — secondary tags are flat labels,
+ * not a category hierarchy, so they are ignored. Each distinct primary lineage
+ * (a deepest primary tag plus its ancestors) yields one trail; a discussion in
+ * two unrelated primary tags therefore produces two BreadcrumbLists.
+ */
+class TagBreadcrumb
+{
+    public function __construct(
+        private readonly UrlGenerator $url,
+    ) {
+    }
+
+    /**
+     * The distinct primary lineages among a discussion's tags. Each lineage is
+     * a list of Crumbs beginning with the "Tags" root and continuing root →
+     * leaf through the primary ancestry. Secondary tags are excluded.
+     *
+     * Returns an empty array when there are no primary tags (e.g. a discussion
+     * tagged only with secondary tags), so the caller emits just Home › title.
+     *
+     * @param Collection<int, Tag> $tags
+     *
+     * @return list<list<Crumb>>
+     */
+    public function primaryLineages(Collection $tags): array
+    {
+        $primary = $tags->filter(fn (Tag $tag) => (bool) $tag->is_primary);
+
+        if ($primary->isEmpty()) {
+            return [];
+        }
+
+        $attachedIds = $primary->map(fn (Tag $tag) => $tag->id)->all();
+
+        // A "leaf" is a primary tag that is not an ancestor of another attached
+        // primary tag — i.e. the most specific tag on each branch. This folds a
+        // primary parent + its attached primary child into a single lineage.
+        $parentIds = $primary
+            ->map(fn (Tag $tag) => $tag->parent_id)
+            ->filter(fn (?int $id) => $id !== null && in_array($id, $attachedIds, true))
+            ->all();
+
+        $leaves = $primary->reject(fn (Tag $tag) => in_array($tag->id, $parentIds, true));
+
+        $lineages = [];
+
+        foreach ($leaves as $leaf) {
+            $crumbs = [new Crumb('Tags', $this->url->to('forum')->route('tags'), 'CollectionPage')];
+
+            foreach ($this->lineage($leaf) as $tag) {
+                $crumbs[] = $this->crumbFor($tag);
+            }
+
+            $lineages[] = $crumbs;
+        }
+
+        return $lineages;
+    }
+
+    /**
+     * Compose the breadcrumb trail(s) for a discussion: Home › {primary
+     * lineage} › {title}, one trail per primary lineage. The first lineage
+     * fills the pre-seeded primary trail; any further lineages are added as
+     * extra trails. With no primary lineages the discussion gets a single
+     * Home › title trail.
+     *
+     * @param Collection<int, Tag> $tags
+     */
+    public function emitDiscussionTrails(SeoProperties $properties, Collection $tags, string $title): void
+    {
+        $lineages = $this->primaryLineages($tags);
+
+        // First (or only) trail uses the pre-seeded primary trail.
+        $first = $properties->breadcrumb();
+
+        foreach ($lineages[0] ?? [] as $crumb) {
+            $first->push($crumb);
+        }
+
+        $first->push(new Crumb($title));
+
+        // Additional primary lineages each become their own trail.
+        foreach (array_slice($lineages, 1) as $lineage) {
+            $trail = $properties->newBreadcrumb();
+
+            foreach ($lineage as $crumb) {
+                $trail->push($crumb);
+            }
+
+            $trail->push(new Crumb($title));
+
+            $properties->addBreadcrumb($trail);
+        }
+    }
+
+    /**
+     * Push "Tags" then the lineage *down to but not including* the given tag —
+     * used on a tag page, where the tag itself is the current (last) crumb. A
+     * tag page is about that tag, so it is shown even for a secondary tag.
+     */
+    public function pushAncestorsOf(BreadcrumbTrail $trail, Tag $tag): void
+    {
+        $trail->push(new Crumb('Tags', $this->url->to('forum')->route('tags'), 'CollectionPage'));
+
+        $lineage = $this->lineage($tag);
+        array_pop($lineage); // drop the tag itself; the caller adds it as the leaf
+
+        foreach ($lineage as $ancestor) {
+            $trail->push($this->crumbFor($ancestor));
+        }
+    }
+
+    public function crumbFor(Tag $tag): Crumb
+    {
+        return new Crumb(
+            $tag->name,
+            $this->url->to('forum')->route('tag', ['slug' => $tag->slug]),
+            'CollectionPage',
+        );
+    }
+
+    /**
+     * The tag's ancestor chain, ordered root → … → tag. Guards against cycles.
+     *
+     * @return list<Tag>
+     */
+    private function lineage(Tag $tag): array
+    {
+        $chain = [];
+        $seen = [];
+        $current = $tag;
+
+        while ($current !== null && !isset($seen[$current->id])) {
+            $seen[$current->id] = true;
+            array_unshift($chain, $current);
+            $current = $current->parent;
+        }
+
+        return $chain;
+    }
+}

--- a/src/Event/BuildingBreadcrumb.php
+++ b/src/Event/BuildingBreadcrumb.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of fof/seo.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Seo\Event;
+
+use FoF\Seo\Breadcrumb\BreadcrumbTrail;
+use FoF\Seo\Breadcrumb\Crumb;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Dispatched after all page drivers have built the breadcrumb trail, but before
+ * it is rendered to schema.org JSON-LD.
+ *
+ * Listeners may add, remove, reorder or relabel crumbs — this is the supported
+ * way for third-party extensions to shape the breadcrumb for any page:
+ *
+ * ```php
+ * (new Extend\Event())->listen(BuildingBreadcrumb::class, function (BuildingBreadcrumb $event) {
+ *     // Add a crumb…
+ *     $event->trail->insertAfter(
+ *         fn ($crumb) => $crumb->name === 'Home',
+ *         new Crumb('Forums', 'https://example.com/forums')
+ *     );
+ *     // …or drop one…
+ *     $event->trail->remove(fn ($crumb) => $crumb->name === 'Unwanted');
+ * });
+ * ```
+ *
+ * A trail with fewer than two crumbs renders to nothing, so removing crumbs can
+ * suppress the breadcrumb entirely.
+ *
+ * @see BreadcrumbTrail
+ * @see Crumb
+ */
+class BuildingBreadcrumb
+{
+    public function __construct(
+        public readonly BreadcrumbTrail $trail,
+        public readonly ServerRequestInterface $request,
+    ) {
+    }
+}

--- a/src/Listeners/PageListener.php
+++ b/src/Listeners/PageListener.php
@@ -14,6 +14,9 @@ namespace FoF\Seo\Listeners;
 use Flarum\Frontend\Document;
 use Flarum\Http\UrlGenerator;
 use Flarum\Settings\SettingsRepositoryInterface;
+use FoF\Seo\Breadcrumb\BreadcrumbTrail;
+use FoF\Seo\Breadcrumb\Crumb;
+use FoF\Seo\Event\BuildingBreadcrumb;
 use FoF\Seo\Event\PreparingPageMeta;
 use FoF\Seo\Page\PageManager;
 use FoF\Seo\SeoMeta\SeoMeta;
@@ -43,9 +46,13 @@ class PageListener
     ];
 
     /**
-     * @var array<string, mixed>
+     * One or more breadcrumb trails for the page. Most pages have a single
+     * trail; a discussion in multiple primary tags emits one trail per primary
+     * lineage (Google allows multiple BreadcrumbLists on a page).
+     *
+     * @var list<BreadcrumbTrail>
      */
-    protected array $schemaBreadcrumb = [];
+    protected array $breadcrumbs = [];
 
     /**
      * Meta data with property tags.
@@ -87,6 +94,11 @@ class PageListener
         // Request type
         $routeName = $serverRequest->getAttribute('routeName');
 
+        // Seed a single breadcrumb trail with a "Home" root. Drivers append
+        // their own crumbs (tag lineage, the page itself, …) on top of this,
+        // and may add further trails via addBreadcrumb().
+        $this->breadcrumbs = [$this->newSeededTrail()];
+
         // Initialize SEO Properties container
         $seoPropertiesExtender = new SeoProperties($this);
 
@@ -94,6 +106,77 @@ class PageListener
         foreach ($this->pageManager->getExtenders($routeName) as $extender) {
             $extender->handle($serverRequest, $seoPropertiesExtender);
         }
+    }
+
+    /**
+     * The primary breadcrumb trail being built for this request, pre-seeded
+     * with a "Home" crumb. Page drivers push crumbs onto it; it is rendered
+     * (and given to the BuildingBreadcrumb event) during finish().
+     */
+    public function breadcrumb(): BreadcrumbTrail
+    {
+        if ($this->breadcrumbs === []) {
+            $this->breadcrumbs = [$this->newSeededTrail()];
+        }
+
+        return $this->breadcrumbs[0];
+    }
+
+    /**
+     * Register an additional breadcrumb trail — e.g. a second primary-tag
+     * lineage for a multi-category discussion. Each trail renders as its own
+     * BreadcrumbList.
+     */
+    public function addBreadcrumb(BreadcrumbTrail $trail): void
+    {
+        $this->breadcrumbs[] = $trail;
+    }
+
+    /**
+     * A fresh trail seeded with the "Home" root crumb.
+     */
+    public function newSeededTrail(): BreadcrumbTrail
+    {
+        return (new BreadcrumbTrail())->push(new Crumb(
+            $this->settings->get('forum_title') ?? 'Home',
+            $this->applicationUrl.'/',
+        ));
+    }
+
+    /**
+     * @return list<BreadcrumbTrail>
+     */
+    public function breadcrumbs(): array
+    {
+        return $this->breadcrumbs;
+    }
+
+    /**
+     * Whether the current page is the one configured as the forum's home
+     * (core's `default_route`). Such a page is the root of the site and should
+     * not carry a breadcrumb of its own. Compares the page's path — taken from
+     * the canonical URL a driver set, falling back to the schema `url` — to the
+     * configured default route.
+     */
+    private function isConfiguredHome(): bool
+    {
+        $defaultRoute = $this->settings->get('default_route');
+
+        if ($defaultRoute === null || $defaultRoute === '') {
+            return false;
+        }
+
+        $pageUrl = $this->canonicalUrl ?? ($this->schemaArray['url'] ?? null);
+
+        if (!is_string($pageUrl)) {
+            return false;
+        }
+
+        // Reduce both to a normalised path for comparison.
+        $pagePath = '/'.trim((string) parse_url($pageUrl, PHP_URL_PATH), '/');
+        $homePath = '/'.trim($defaultRoute, '/');
+
+        return $pagePath === $homePath;
     }
 
     /**
@@ -159,6 +242,19 @@ class PageListener
             $this->setSchemaJson('inLanguage', $locale);
         }
 
+        // A page that is itself the configured forum home is the root — it
+        // gets no breadcrumb of its own (avoids "Home › Home").
+        if ($this->isConfiguredHome()) {
+            $this->breadcrumbs = [];
+        }
+
+        // Let extensions add/remove/modify breadcrumb crumbs before they are
+        // rendered. Fired before PreparingPageMeta so general meta listeners
+        // observe the final trails.
+        foreach ($this->breadcrumbs as $trail) {
+            $this->events->dispatch(new BuildingBreadcrumb($trail, $serverRequest));
+        }
+
         // Let extensions read and modify the prepared metadata before it is written.
         $this->events->dispatch(
             new PreparingPageMeta(new SeoProperties($this), $this->flarumDocument, $serverRequest)
@@ -208,8 +304,14 @@ class PageListener
         $show = [];
         $show[] = $this->schemaArray;
 
-        if (count($this->schemaBreadcrumb) > 0) {
-            $show[] = $this->schemaBreadcrumb;
+        // Each trail renders as its own BreadcrumbList (null when it has fewer
+        // than two crumbs, e.g. on the forum home).
+        foreach ($this->breadcrumbs as $trail) {
+            $breadcrumb = $trail->toSchema();
+
+            if ($breadcrumb !== null) {
+                $show[] = $breadcrumb;
+            }
         }
 
         $show[] = $this->addSearchBar();
@@ -260,38 +362,20 @@ class PageListener
 
     /**
      * @param array<int, array<string, mixed>> $tagList
-     * @param string                           $listOrderType https://schema.org/ItemListOrderType
+     * @param string                           $listOrderType (unused; kept for BC)
+     *
+     * @deprecated Push crumbs onto breadcrumb() instead. This converts the
+     *             legacy tag array into Crumbs appended to the trail.
      */
     public function setSchemaBreadcrumb(array $tagList = [], string $listOrderType = 'ItemListUnordered'): void
     {
-        // Don't add the list, there were no tags
-        if (count($tagList) === 0) {
-            return;
+        foreach ($tagList as $tag) {
+            $this->breadcrumb()->push(new Crumb(
+                Arr::get($tag, 'name', 'Unknown'),
+                Arr::get($tag, 'url'),
+                Arr::get($tag, 'type', 'WebPage'),
+            ));
         }
-
-        $list = [];
-
-        // Loop through all tags
-        foreach ($tagList as $index => $tag) {
-            $list[] = [
-                '@type'    => 'ListItem',
-                'position' => ($index + 1),
-                'item'     => [
-                    '@type' => Arr::get($tag, 'type', 'Thing'),
-                    '@id'   => Arr::get($tag, 'url', $this->applicationUrl),
-                    'name'  => Arr::get($tag, 'name', 'Unknown'),
-                    'url'   => Arr::get($tag, 'url', $this->applicationUrl),
-                ],
-            ];
-        }
-
-        $this->schemaBreadcrumb = [
-            '@context'        => 'http://schema.org',
-            '@type'           => 'BreadcrumbList',
-            'itemListElement' => $list,
-            'itemListOrder'   => $listOrderType,
-            'numberOfItems'   => count($list),
-        ];
     }
 
     /**

--- a/src/Page/DiscussionBestAnswerPage.php
+++ b/src/Page/DiscussionBestAnswerPage.php
@@ -12,9 +12,11 @@
 namespace FoF\Seo\Page;
 
 use Flarum\Database\Eloquent\Collection;
+use Flarum\Discussion\Discussion as FlarumDiscussion;
 use Flarum\Discussion\DiscussionRepository;
 use Flarum\Extension\ExtensionManager;
 use Flarum\Foundation\DispatchEventsTrait;
+use Flarum\Http\RequestUtil;
 use Flarum\Http\SlugManager;
 use Flarum\Http\UrlGenerator;
 use Flarum\Post\CommentPost;
@@ -23,6 +25,7 @@ use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Tags\Tag;
 use Flarum\User\User;
 use Flarum\User\UserRepository;
+use FoF\Seo\Breadcrumb\TagBreadcrumb;
 use FoF\Seo\SeoMeta\SeoMeta;
 use FoF\Seo\SeoProperties;
 use FoF\Seo\Support\PostMedia;
@@ -88,18 +91,26 @@ class DiscussionBestAnswerPage implements PageDriverInterface
         ServerRequestInterface $request,
         SeoProperties $properties
     ): void {
-        // Get discussion ID from params
-        // Cast to int to extract the numeric id from the `{id}-{slug}` route
-        // param so the lookup works on all databases (SQLite won't coerce it).
-        $discussionId = (int) Arr::get($request->getQueryParams(), 'id');
+        $slug = Arr::get($request->getQueryParams(), 'id');
+
+        if ($slug === null) {
+            return;
+        }
 
         try {
-            // Find discussion
-            $discussion = $this->discussionRepository->findOrFail($discussionId);
+            // Resolve through the configured discussion slug driver.
+            /** @var FlarumDiscussion $discussion */
+            $discussion = $this->slugManager->forResource(FlarumDiscussion::class)->fromSlug(
+                $slug,
+                RequestUtil::getActor($request)
+            );
         } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
             // Do nothing, no model found
             return;
         }
+
+        // The canonical discussion slug under the configured driver, for URLs.
+        $discussionSlug = $this->slugManager->forResource(FlarumDiscussion::class)->toSlug($discussion);
 
         // When best-answer isn't installed, DiscussionPage emits the standard
         // DiscussionForumPosting, so there's nothing for us to do.
@@ -174,7 +185,7 @@ class DiscussionBestAnswerPage implements PageDriverInterface
         $bestAnswerId = $discussion->best_answer_post_id;
 
         // Update topic url
-        $properties->setUrl($this->urlGenerator->to('forum')->route('discussion', ['id' => $discussion->id.'-'.$discussion->slug]), false);
+        $properties->setUrl($this->urlGenerator->to('forum')->route('discussion', ['id' => $discussionSlug]), false);
 
         // Schema
         $mainEntity = [
@@ -201,15 +212,9 @@ class DiscussionBestAnswerPage implements PageDriverInterface
             $mainEntity['upvoteCount'] = $firstPost->likes()->count();
         }
 
-        // Generate a breadcrumb if discussion has tags
-        if ($discussionTags->count() >= 1) {
-            $properties->generateSchemaBreadcrumb(
-                $discussionTags->map(fn (Tag $tag) => [
-                    'name' => $tag->name,
-                    'url'  => $this->urlGenerator->to('forum')->route('tag', ['slug' => $tag->slug]),
-                ])->toArray()
-            );
-        }
+        // Breadcrumb: Home › Tags › {primary lineage} › {discussion title}, one
+        // trail per primary lineage (secondary tags excluded).
+        (new TagBreadcrumb($this->urlGenerator))->emitDiscussionTrails($properties, $discussionTags, $discussion->title);
 
         // Only add suggested answers property if there are posts
         $mainEntity['suggestedAnswer'] = [];
@@ -247,7 +252,7 @@ class DiscussionBestAnswerPage implements PageDriverInterface
             $generatedPost = [
                 '@type'       => 'Answer',
                 'dateCreated' => $post->created_at->toIso8601String(),
-                'url'         => $this->urlGenerator->to('forum')->route('discussion', ['id' => $discussion->id.'-'.$discussion->slug, 'near' => $post->number]),
+                'url'         => $this->urlGenerator->to('forum')->route('discussion', ['id' => $discussionSlug, 'near' => $post->number]),
             ] + PostMedia::schemaFields($post->formatContent());
 
             // Omit `author` when this post's user is deleted — see authorSchema().

--- a/src/Page/DiscussionPage.php
+++ b/src/Page/DiscussionPage.php
@@ -16,6 +16,7 @@ use Flarum\Discussion\Discussion as FlarumDiscussion;
 use Flarum\Discussion\DiscussionRepository;
 use Flarum\Extension\ExtensionManager;
 use Flarum\Foundation\DispatchEventsTrait;
+use Flarum\Http\RequestUtil;
 use Flarum\Http\SlugManager;
 use Flarum\Http\UrlGenerator;
 use Flarum\Post\CommentPost;
@@ -24,6 +25,7 @@ use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Tags\Tag;
 use Flarum\User\User;
 use Flarum\User\UserRepository;
+use FoF\Seo\Breadcrumb\TagBreadcrumb;
 use FoF\Seo\SeoMeta\SeoMeta;
 use FoF\Seo\SeoProperties;
 use FoF\Seo\Support\PostMedia;
@@ -104,7 +106,7 @@ class DiscussionPage implements PageDriverInterface
             // `dateCreated` too for schema.org completeness.
             'datePublished' => $post->created_at->toIso8601String(),
             'dateCreated'   => $post->created_at->toIso8601String(),
-            'url'           => $this->urlGenerator->to('forum')->route('discussion', ['id' => $discussion->id.'-'.$discussion->slug, 'near' => $post->number]),
+            'url'           => $this->urlGenerator->to('forum')->route('discussion', ['id' => $this->slugManager->forResource(FlarumDiscussion::class)->toSlug($discussion), 'near' => $post->number]),
         ] + $media;
 
         // Omit `author` when the commenter is deleted — see authorSchema().
@@ -147,18 +149,27 @@ class DiscussionPage implements PageDriverInterface
         ServerRequestInterface $request,
         SeoProperties $properties
     ): void {
-        // Get discussion ID from params. The route param is the `{id}-{slug}`
-        // form (e.g. "1-bake-bread"); cast to int to extract the numeric id so
-        // the lookup works regardless of database (SQLite won't coerce it).
-        $discussionId = (int) Arr::get($request->getQueryParams(), 'id');
+        $slug = Arr::get($request->getQueryParams(), 'id');
+
+        if ($slug === null) {
+            return;
+        }
 
         try {
-            // Find discussion
-            $discussion = $this->discussionRepository->findOrFail($discussionId);
+            // Resolve through the configured discussion slug driver, so the
+            // lookup works whatever form the `/d/{id}` route param takes.
+            /** @var FlarumDiscussion $discussion */
+            $discussion = $this->slugManager->forResource(FlarumDiscussion::class)->fromSlug(
+                $slug,
+                RequestUtil::getActor($request)
+            );
         } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
             // Do nothing, no model found
             return;
         }
+
+        // The canonical discussion slug under the configured driver, for URLs.
+        $discussionSlug = $this->slugManager->forResource(FlarumDiscussion::class)->toSlug($discussion);
 
         $tagsEnabled = $this->extensionManager->isEnabled('flarum-tags');
         $enableBestAnswer = $this->extensionManager->isEnabled('fof-best-answer');
@@ -203,7 +214,7 @@ class DiscussionPage implements PageDriverInterface
         $properties->generateTagsFromMetaData($seoMeta);
 
         // Update topic url
-        $properties->setUrl($this->urlGenerator->to('forum')->route('discussion', ['id' => $discussion->id.'-'.$discussion->slug]), false);
+        $properties->setUrl($this->urlGenerator->to('forum')->route('discussion', ['id' => $discussionSlug]), false);
 
         // Optional fof/discussion-language integration: a discussion's own
         // language drives inLanguage, overriding the viewer's locale.
@@ -328,15 +339,12 @@ class DiscussionPage implements PageDriverInterface
             $properties->setSchemaJson('author', $discussionAuthor);
         }
 
-        // Generate a breadcrum if discussion has tags
-        if ($tagsEnabled && $discussionTags->count() >= 1) {
-            $properties->generateSchemaBreadcrumb(
-                $discussionTags->map(fn (Tag $tag) => [
-                    'name' => $tag->name,
-                    'url'  => $this->urlGenerator->to('forum')->route('tag', ['slug' => $tag->slug]),
-                ])->toArray()
-            );
-        }
+        // Breadcrumb: Home › Tags › {primary lineage} › {discussion title}. Each
+        // distinct primary-tag lineage produces its own trail; secondary tags
+        // are not part of any breadcrumb path. With no primary tags (untagged,
+        // or secondary-only) the trail is simply Home › title.
+        $tags = $tagsEnabled ? $discussionTags : new Collection();
+        (new TagBreadcrumb($this->urlGenerator))->emitDiscussionTrails($properties, $tags, $discussion->title);
 
         // Keep discussions in admin-excluded tags out of the index (GH #117).
         // Overrides the robots directive set by generateTagsFromMetaData above.

--- a/src/Page/PageExtensionPage.php
+++ b/src/Page/PageExtensionPage.php
@@ -13,6 +13,7 @@ namespace FoF\Seo\Page;
 
 use Carbon\Carbon;
 use FoF\Pages\PageRepository;
+use FoF\Seo\Breadcrumb\Crumb;
 use FoF\Seo\SeoMeta\SeoMeta;
 use FoF\Seo\SeoProperties;
 use Illuminate\Support\Arr;
@@ -84,5 +85,8 @@ class PageExtensionPage implements PageDriverInterface
             ->setCanonicalUrl('/p/'.$page->getAttribute('id'))
 
             ->generateTagsFromMetaData($seoMeta);
+
+        // Breadcrumb: Home › {page title}. The page is the current page.
+        $properties->breadcrumb()->push(new Crumb($page->title));
     }
 }

--- a/src/Page/ProfilePage.php
+++ b/src/Page/ProfilePage.php
@@ -11,8 +11,11 @@
 
 namespace FoF\Seo\Page;
 
+use Flarum\Http\RequestUtil;
+use Flarum\Http\SlugManager;
 use Flarum\Settings\SettingsRepositoryInterface;
-use Flarum\User\UserRepository;
+use Flarum\User\User;
+use FoF\Seo\Breadcrumb\Crumb;
 use FoF\Seo\SeoProperties;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
@@ -21,9 +24,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class ProfilePage implements PageDriverInterface
 {
     public function __construct(
-        protected readonly UserRepository $userRepository,
         protected readonly TranslatorInterface $translator,
         protected readonly SettingsRepositoryInterface $settings,
+        protected readonly SlugManager $slugManager,
     ) {
     }
 
@@ -41,19 +44,29 @@ class ProfilePage implements PageDriverInterface
         ServerRequestInterface $request,
         SeoProperties $properties
     ): void {
-        $username = Arr::get($request->getQueryParams(), 'username');
+        $slug = Arr::get($request->getQueryParams(), 'username');
 
-        try {
-            $user = is_numeric($username) ? $this->userRepository->findOrFail($username) : $this->userRepository->findByIdentification($username);
-
-            // Make sure there's a user
-            if ($user === null) {
-                return;
-            }
-        } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
-            // Do nothing. It just did not work
+        if ($slug === null) {
             return;
         }
+
+        try {
+            // Resolve through the configured user slug driver (username, id,
+            // id-with-name, or a third-party driver) — the `/u/{username}` route
+            // param is whatever that driver produced, not necessarily a username.
+            /** @var User $user */
+            $user = $this->slugManager->forResource(User::class)->fromSlug(
+                $slug,
+                RequestUtil::getActor($request)
+            );
+        } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+            // No user matched the slug.
+            return;
+        }
+
+        // The canonical profile slug under the configured driver (e.g. the
+        // username, or `{id}-{name}`), used to build all profile URLs.
+        $userSlug = $this->slugManager->forResource(User::class)->toSlug($user);
 
         // Profile title
         $profileTitle = $this->translator->trans('fof-seo.forum.profile_title', [
@@ -74,7 +87,7 @@ class ProfilePage implements PageDriverInterface
             'name'                      => $user->getAttribute('display_name'),
             'alternateName'             => $user->getAttribute('username'),
             'identifier'                => $user->id,
-            'url'                       => $properties->withApplicationPath('/u/'.$user->getAttribute('username')),
+            'url'                       => $properties->withApplicationPath('/u/'.$userSlug),
             'agentInteractionStatistic' => [
                 [
                     '@type'                => 'InteractionCounter',
@@ -129,10 +142,13 @@ class ProfilePage implements PageDriverInterface
             ->setDescription($profileDescription)
 
             // Profile URL
-            ->setUrl('/u/'.$user->getAttribute('username'))
+            ->setUrl('/u/'.$userSlug)
 
             // Canonical url
-            ->setCanonicalUrl('/u/'.$user->getAttribute('username'));
+            ->setCanonicalUrl('/u/'.$userSlug);
+
+        // Breadcrumb: Home › {display name}. The profile is the current page.
+        $properties->breadcrumb()->push(new Crumb($user->getAttribute('display_name')));
 
         // Optionally keep thin profile pages out of the search index (GH #62).
         // Links are still followed so crawlers can reach the content they link to.

--- a/src/Page/TagPage.php
+++ b/src/Page/TagPage.php
@@ -11,8 +11,13 @@
 
 namespace FoF\Seo\Page;
 
+use Flarum\Discussion\Discussion as FlarumDiscussion;
 use Flarum\Foundation\DispatchEventsTrait;
+use Flarum\Http\SlugManager;
+use Flarum\Http\UrlGenerator;
 use Flarum\Tags\TagRepository;
+use FoF\Seo\Breadcrumb\Crumb;
+use FoF\Seo\Breadcrumb\TagBreadcrumb;
 use FoF\Seo\SeoMeta\SeoMeta;
 use FoF\Seo\SeoProperties;
 use FoF\Seo\TagIndexingPolicy;
@@ -31,6 +36,8 @@ class TagPage implements PageDriverInterface
         protected readonly TranslatorInterface $translator,
         Dispatcher $events,
         protected readonly TagIndexingPolicy $tagIndexingPolicy,
+        protected readonly UrlGenerator $urlGenerator,
+        protected readonly SlugManager $slugManager,
     ) {
         $this->events = $events;
     }
@@ -81,6 +88,12 @@ class TagPage implements PageDriverInterface
             // Canonical url
             ->setCanonicalUrl('/t/'.$tag->slug);
 
+        // Breadcrumb: Home › Tags › {ancestors} › {this tag}. The tag itself is
+        // the current page, so it has no url.
+        $tagBreadcrumb = new TagBreadcrumb($this->urlGenerator);
+        $tagBreadcrumb->pushAncestorsOf($properties->breadcrumb(), $tag);
+        $properties->breadcrumb()->push(new Crumb($tag->name));
+
         // List the tag's most recent public discussions as a schema.org ItemList.
         $discussions = $tag->discussions()
             ->where('is_private', false)
@@ -89,10 +102,12 @@ class TagPage implements PageDriverInterface
             ->limit(20)
             ->get();
 
+        $discussionSlugger = $this->slugManager->forResource(FlarumDiscussion::class);
+
         $itemListElement = $discussions->values()->map(fn ($discussion, int $index) => [
             '@type'    => 'ListItem',
             'position' => $index + 1,
-            'url'      => $properties->withApplicationPath('/d/'.$discussion->id.'-'.$discussion->slug),
+            'url'      => $properties->withApplicationPath('/d/'.$discussionSlugger->toSlug($discussion)),
             'name'     => $discussion->title,
         ])->toArray();
 

--- a/src/Page/TagsPage.php
+++ b/src/Page/TagsPage.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of fof/seo.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Seo\Page;
+
+use Flarum\Settings\SettingsRepositoryInterface;
+use FoF\Seo\Breadcrumb\Crumb;
+use FoF\Seo\SeoProperties;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * The all-tags listing page registered by flarum/tags at `/tags`.
+ */
+class TagsPage implements PageDriverInterface
+{
+    public function __construct(
+        protected readonly TranslatorInterface $translator,
+        protected readonly SettingsRepositoryInterface $settings,
+    ) {
+    }
+
+    public function extensionDependencies(): array
+    {
+        return ['flarum-tags'];
+    }
+
+    public function handleRoutes(): array
+    {
+        return ['tags'];
+    }
+
+    public function handle(
+        ServerRequestInterface $request,
+        SeoProperties $properties
+    ): void {
+        $title = $this->translator->trans('flarum-tags.forum.all_tags.meta_title_text');
+
+        $properties
+            ->setSchemaJson('@type', 'CollectionPage')
+            ->setSchemaJson('name', $title)
+            ->setTitle($title)
+            ->setUrl('/tags')
+            ->setCanonicalUrl('/tags');
+
+        // Breadcrumb: Home › Tags. "Tags" is the current page (no url).
+        $properties->breadcrumb()->push(new Crumb($title));
+    }
+}

--- a/src/Page/UserDirectoryPage.php
+++ b/src/Page/UserDirectoryPage.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of fof/seo.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Seo\Page;
+
+use FoF\Seo\Breadcrumb\Crumb;
+use FoF\Seo\SeoProperties;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * The members listing page registered by fof/user-directory at `/users`.
+ */
+class UserDirectoryPage implements PageDriverInterface
+{
+    public function __construct(
+        protected readonly TranslatorInterface $translator,
+    ) {
+    }
+
+    public function extensionDependencies(): array
+    {
+        return ['fof-user-directory'];
+    }
+
+    public function handleRoutes(): array
+    {
+        return ['fof_user_directory'];
+    }
+
+    public function handle(
+        ServerRequestInterface $request,
+        SeoProperties $properties
+    ): void {
+        $title = $this->translator->trans('fof-user-directory.forum.page.nav');
+
+        $properties
+            ->setSchemaJson('@type', 'CollectionPage')
+            ->setSchemaJson('name', $title)
+            ->setTitle($title)
+            ->setUrl('/users')
+            ->setCanonicalUrl('/users');
+
+        // Breadcrumb: Home › User Directory. It is the current page (no url).
+        $properties->breadcrumb()->push(new Crumb($title));
+    }
+}

--- a/src/SeoProperties.php
+++ b/src/SeoProperties.php
@@ -11,6 +11,7 @@
 
 namespace FoF\Seo;
 
+use FoF\Seo\Breadcrumb\BreadcrumbTrail;
 use FoF\Seo\Listeners\PageListener;
 use FoF\Seo\SeoMeta\SeoMeta;
 
@@ -217,9 +218,48 @@ class SeoProperties
     }
 
     /**
-     * Generates a schema.org breadcrumb list.
+     * The breadcrumb trail for the current request, pre-seeded with a "Home"
+     * crumb. Page drivers push their crumbs onto it; third parties reshape it
+     * via the {@see \FoF\Seo\Event\BuildingBreadcrumb} event.
+     *
+     * ```php
+     * $properties->breadcrumb()
+     *     ->push(new Crumb($tag->name, $tagUrl))
+     *     ->push(new Crumb($discussion->title)); // current page: no url
+     * ```
+     */
+    public function breadcrumb(): BreadcrumbTrail
+    {
+        return $this->container->breadcrumb();
+    }
+
+    /**
+     * A fresh breadcrumb trail seeded with the "Home" root, for building an
+     * additional trail (e.g. a second primary-tag lineage). Register it with
+     * {@see addBreadcrumb()}.
+     */
+    public function newBreadcrumb(): BreadcrumbTrail
+    {
+        return $this->container->newSeededTrail();
+    }
+
+    /**
+     * Register an additional breadcrumb trail; each renders as its own
+     * schema.org BreadcrumbList.
+     */
+    public function addBreadcrumb(BreadcrumbTrail $trail): self
+    {
+        $this->container->addBreadcrumb($trail);
+
+        return $this;
+    }
+
+    /**
+     * Generates a schema.org breadcrumb list from a flat tag array.
      *
      * @param array<int, array<string, mixed>> $tags
+     *
+     * @deprecated Use {@see breadcrumb()} and push Crumb objects instead.
      */
     public function generateSchemaBreadcrumb(array $tags): self
     {

--- a/tests/integration/forum/BreadcrumbTest.php
+++ b/tests/integration/forum/BreadcrumbTest.php
@@ -1,0 +1,431 @@
+<?php
+
+/*
+ * This file is part of fof/seo.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Seo\Tests\integration\forum;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Extend;
+use Flarum\Post\Post;
+use Flarum\Tags\Tag;
+use FoF\Seo\Breadcrumb\Crumb;
+use FoF\Seo\Event\BuildingBreadcrumb;
+use FoF\Seo\Tests\integration\ForumHtmlTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * End-to-end coverage of the breadcrumb system across the three layers:
+ * core pages, flarum/tags, and supported extensions — plus the extensible
+ * BuildingBreadcrumb event.
+ */
+class BreadcrumbTest extends ForumHtmlTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-seo');
+
+        $this->setting('forum_title', 'My Forum');
+        // A neutral default route so individual pages are never "home".
+        $this->setting('default_route', '/all');
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function crumbNames(string $html): array
+    {
+        $breadcrumb = $this->findSchemaEntry($html, 'BreadcrumbList');
+
+        return $breadcrumb === null ? [] : array_column($breadcrumb['itemListElement'], 'name');
+    }
+
+    private function countQueriesFor(string $path): int
+    {
+        /** @var \Illuminate\Database\Connection $db */
+        $db = $this->database();
+        $db->flushQueryLog();
+        $db->enableQueryLog();
+        $this->fetchForumHtml($path);
+        $count = count($db->getQueryLog());
+        $db->disableQueryLog();
+
+        return $count;
+    }
+
+    // ----- Core pages (no flarum/tags) -----------------------------------
+
+    #[Test]
+    public function a_discussion_without_tags_gets_a_home_then_title_trail(): void
+    {
+        $this->prepareDatabase([
+            Discussion::class => [
+                ['id' => 1, 'title' => 'Plain discussion', 'slug' => 'plain', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'created_at' => Carbon::now()],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Body.</p></t>', 'created_at' => Carbon::now()],
+            ],
+        ]);
+
+        $this->assertSame(['My Forum', 'Plain discussion'], $this->crumbNames($this->fetchForumHtml('/d/1-plain')));
+    }
+
+    #[Test]
+    public function the_last_crumb_omits_item_and_home_links_to_root(): void
+    {
+        $this->prepareDatabase([
+            Discussion::class => [
+                ['id' => 1, 'title' => 'Plain discussion', 'slug' => 'plain', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'created_at' => Carbon::now()],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Body.</p></t>', 'created_at' => Carbon::now()],
+            ],
+        ]);
+
+        $items = $this->findSchemaEntry($this->fetchForumHtml('/d/1-plain'), 'BreadcrumbList')['itemListElement'];
+
+        $this->assertSame('http://localhost/', $items[0]['item']['url'] ?? null);
+        $this->assertArrayNotHasKey('item', $items[1]);
+    }
+
+    #[Test]
+    public function a_profile_page_gets_a_home_then_name_trail(): void
+    {
+        $this->assertSame(['My Forum', 'admin'], $this->crumbNames($this->fetchForumHtml('/u/admin')));
+    }
+
+    #[Test]
+    public function the_forum_home_page_emits_no_breadcrumb(): void
+    {
+        // default_route is /all, so /all is the home page.
+        $this->assertNull($this->findSchemaEntry($this->fetchForumHtml('/all'), 'BreadcrumbList'));
+    }
+
+    #[Test]
+    public function a_page_that_is_the_configured_home_emits_no_breadcrumb(): void
+    {
+        // Point the forum home at a specific user's profile.
+        $this->setting('default_route', '/u/admin');
+
+        $this->assertNull($this->findSchemaEntry($this->fetchForumHtml('/u/admin'), 'BreadcrumbList'));
+    }
+
+    // ----- flarum/tags layer ---------------------------------------------
+
+    #[Test]
+    public function a_tagged_discussion_includes_the_tag_lineage(): void
+    {
+        $this->extension('flarum-tags');
+
+        $this->prepareDatabase([
+            Tag::class => [
+                ['id' => 1, 'name' => 'Support', 'slug' => 'support', 'description' => null, 'color' => '#000', 'position' => 0, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => true],
+                ['id' => 2, 'name' => 'Installation', 'slug' => 'installation', 'description' => null, 'color' => '#000', 'position' => 0, 'parent_id' => 1, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => true],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'How do I install?', 'slug' => 'how-install', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'created_at' => Carbon::now()],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Body.</p></t>', 'created_at' => Carbon::now()],
+            ],
+            // Tagged only with the child primary; its parent must still appear, in order.
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => 2],
+            ],
+        ]);
+
+        $this->assertSame(
+            ['My Forum', 'Tags', 'Support', 'Installation', 'How do I install?'],
+            $this->crumbNames($this->fetchForumHtml('/d/1-how-install'))
+        );
+    }
+
+    #[Test]
+    public function the_primary_tag_lineage_is_chosen_for_a_multi_tag_discussion(): void
+    {
+        $this->extension('flarum-tags');
+
+        $this->prepareDatabase([
+            Tag::class => [
+                ['id' => 1, 'name' => 'Chatter', 'slug' => 'chatter', 'description' => null, 'color' => '#000', 'position' => 0, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => false],
+                ['id' => 2, 'name' => 'Support', 'slug' => 'support', 'description' => null, 'color' => '#000', 'position' => 1, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => true],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'Mixed', 'slug' => 'mixed', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'created_at' => Carbon::now()],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Body.</p></t>', 'created_at' => Carbon::now()],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => 1],
+                ['discussion_id' => 1, 'tag_id' => 2],
+            ],
+        ]);
+
+        // The primary tag (Support) forms the lineage, not the secondary one.
+        $this->assertSame(
+            ['My Forum', 'Tags', 'Support', 'Mixed'],
+            $this->crumbNames($this->fetchForumHtml('/d/1-mixed'))
+        );
+    }
+
+    #[Test]
+    public function a_single_primary_tag_forms_a_one_level_lineage(): void
+    {
+        $this->extension('flarum-tags');
+
+        $this->prepareDatabase([
+            Tag::class => [
+                ['id' => 1, 'name' => 'Support', 'slug' => 'support', 'description' => null, 'color' => '#000', 'position' => 0, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => true],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'Q', 'slug' => 'q', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'created_at' => Carbon::now()],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Body.</p></t>', 'created_at' => Carbon::now()],
+            ],
+            'discussion_tag' => [['discussion_id' => 1, 'tag_id' => 1]],
+        ]);
+
+        $this->assertSame(
+            ['My Forum', 'Tags', 'Support', 'Q'],
+            $this->crumbNames($this->fetchForumHtml('/d/1-q'))
+        );
+    }
+
+    #[Test]
+    public function a_primary_parent_and_its_primary_child_fold_into_one_lineage(): void
+    {
+        $this->extension('flarum-tags');
+
+        // Both the primary parent and its primary child are attached. They
+        // must collapse to a single lineage ending at the child — not two.
+        $this->prepareDatabase([
+            Tag::class => [
+                ['id' => 1, 'name' => 'Support', 'slug' => 'support', 'description' => null, 'color' => '#000', 'position' => 0, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => true],
+                ['id' => 2, 'name' => 'Installation', 'slug' => 'installation', 'description' => null, 'color' => '#000', 'position' => 0, 'parent_id' => 1, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => true],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'Q', 'slug' => 'q', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'created_at' => Carbon::now()],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Body.</p></t>', 'created_at' => Carbon::now()],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => 1],
+                ['discussion_id' => 1, 'tag_id' => 2],
+            ],
+        ]);
+
+        $html = $this->fetchForumHtml('/d/1-q');
+
+        // Exactly one BreadcrumbList, folding parent + child.
+        $lists = array_filter($this->findSchemaJsonLd($html) ?? [], fn ($e) => ($e['@type'] ?? null) === 'BreadcrumbList');
+        $this->assertCount(1, $lists);
+        $this->assertSame(
+            ['My Forum', 'Tags', 'Support', 'Installation', 'Q'],
+            $this->crumbNames($html)
+        );
+    }
+
+    #[Test]
+    public function dual_primary_tags_emit_one_breadcrumb_list_each(): void
+    {
+        $this->extension('flarum-tags');
+
+        // Two unrelated primary tags → two separate trails.
+        $this->prepareDatabase([
+            Tag::class => [
+                ['id' => 1, 'name' => 'Support', 'slug' => 'support', 'description' => null, 'color' => '#000', 'position' => 0, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => true],
+                ['id' => 2, 'name' => 'Bugs', 'slug' => 'bugs', 'description' => null, 'color' => '#000', 'position' => 1, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => true],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'Q', 'slug' => 'q', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'created_at' => Carbon::now()],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Body.</p></t>', 'created_at' => Carbon::now()],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => 1],
+                ['discussion_id' => 1, 'tag_id' => 2],
+            ],
+        ]);
+
+        $html = $this->fetchForumHtml('/d/1-q');
+
+        $lists = array_values(array_filter(
+            $this->findSchemaJsonLd($html) ?? [],
+            fn ($e) => ($e['@type'] ?? null) === 'BreadcrumbList'
+        ));
+
+        $this->assertCount(2, $lists, 'Expected one BreadcrumbList per primary tag.');
+
+        $trails = array_map(fn ($l) => array_column($l['itemListElement'], 'name'), $lists);
+
+        $this->assertContains(['My Forum', 'Tags', 'Support', 'Q'], $trails);
+        $this->assertContains(['My Forum', 'Tags', 'Bugs', 'Q'], $trails);
+    }
+
+    #[Test]
+    public function a_secondary_only_discussion_skips_the_tag_in_the_trail(): void
+    {
+        $this->extension('flarum-tags');
+
+        // A flat secondary tag is not a category path — the trail is just
+        // Home › title, and there is a single BreadcrumbList.
+        $this->prepareDatabase([
+            Tag::class => [
+                ['id' => 1, 'name' => 'Announcements', 'slug' => 'announcements', 'description' => null, 'color' => '#000', 'position' => 0, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => false],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'Q', 'slug' => 'q', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'created_at' => Carbon::now()],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Body.</p></t>', 'created_at' => Carbon::now()],
+            ],
+            'discussion_tag' => [['discussion_id' => 1, 'tag_id' => 1]],
+        ]);
+
+        $html = $this->fetchForumHtml('/d/1-q');
+
+        // Trail is Home › title; the secondary tag is not a crumb.
+        $this->assertSame(['My Forum', 'Q'], $this->crumbNames($html));
+
+        $lists = array_filter($this->findSchemaJsonLd($html) ?? [], fn ($e) => ($e['@type'] ?? null) === 'BreadcrumbList');
+        $this->assertCount(1, $lists);
+    }
+
+    #[Test]
+    public function a_tag_page_trail_ends_at_the_tag(): void
+    {
+        $this->extension('flarum-tags');
+
+        $this->prepareDatabase([
+            Tag::class => [
+                ['id' => 1, 'name' => 'Support', 'slug' => 'support', 'description' => null, 'color' => '#000', 'position' => 0, 'is_restricted' => false, 'is_hidden' => false],
+                ['id' => 2, 'name' => 'Installation', 'slug' => 'installation', 'description' => null, 'color' => '#000', 'position' => 0, 'parent_id' => 1, 'is_restricted' => false, 'is_hidden' => false],
+            ],
+        ]);
+
+        $this->assertSame(
+            ['My Forum', 'Tags', 'Support', 'Installation'],
+            $this->crumbNames($this->fetchForumHtml('/t/installation'))
+        );
+    }
+
+    #[Test]
+    public function the_all_tags_page_gets_a_home_then_tags_trail(): void
+    {
+        $this->extension('flarum-tags');
+
+        $items = $this->findSchemaEntry($this->fetchForumHtml('/tags'), 'BreadcrumbList')['itemListElement'] ?? [];
+
+        // Home, then the all-tags page as the current (last) crumb. The tag
+        // page's own title comes from flarum/tags' translations, so assert the
+        // structure rather than the exact label.
+        $this->assertCount(2, $items);
+        $this->assertSame('My Forum', $items[0]['name']);
+        $this->assertSame('http://localhost/', $items[0]['item']['url'] ?? null);
+        // The all-tags page is the current page: last crumb, no `item`.
+        $this->assertArrayNotHasKey('item', $items[1]);
+    }
+
+    // ----- Extensible event ----------------------------------------------
+
+    #[Test]
+    public function a_listener_can_add_remove_and_relabel_crumbs(): void
+    {
+        $this->extend(
+            (new Extend\Event())->listen(BuildingBreadcrumb::class, function (BuildingBreadcrumb $event) {
+                $event->trail
+                    ->insertAfter(fn (Crumb $c) => $c->name === 'My Forum', new Crumb('Inserted', 'http://localhost/inserted'))
+                    ->map(fn (Crumb $c) => $c->name === 'My Forum' ? new Crumb('Renamed Home', $c->url) : $c);
+            })
+        );
+
+        $this->prepareDatabase([
+            Discussion::class => [
+                ['id' => 1, 'title' => 'Plain', 'slug' => 'plain', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'created_at' => Carbon::now()],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Body.</p></t>', 'created_at' => Carbon::now()],
+            ],
+        ]);
+
+        $this->assertSame(
+            ['Renamed Home', 'Inserted', 'Plain'],
+            $this->crumbNames($this->fetchForumHtml('/d/1-plain'))
+        );
+    }
+
+    // ----- Supported extensions: fof/user-directory ----------------------
+
+    #[Test]
+    public function the_user_directory_page_gets_a_home_then_directory_trail(): void
+    {
+        $this->extension('fof-user-directory');
+
+        // /users requires the `seeUserList` permission; fetch as the admin.
+        $items = $this->findSchemaEntry($this->fetchForumHtml('/users', 1), 'BreadcrumbList')['itemListElement'] ?? [];
+
+        // Home, then the directory page as the current (last) crumb. The label
+        // comes from fof/user-directory's translations, so assert structure.
+        $this->assertCount(2, $items);
+        $this->assertSame('My Forum', $items[0]['name']);
+        $this->assertSame('http://localhost/', $items[0]['item']['url'] ?? null);
+        $this->assertArrayNotHasKey('item', $items[1]);
+    }
+
+    // ----- Performance ----------------------------------------------------
+
+    #[Test]
+    public function building_the_tag_lineage_does_not_issue_per_level_queries(): void
+    {
+        $this->extension('flarum-tags');
+
+        // An untagged discussion vs. one in a two-level primary tag chain. The
+        // breadcrumb walks the tag's parent chain, but core eager-loads
+        // `tags.parent`, so the query count must not grow per tag level.
+        $this->prepareDatabase([
+            Tag::class => [
+                ['id' => 1, 'name' => 'Support', 'slug' => 'support', 'description' => null, 'color' => '#000', 'position' => 0, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => true],
+                ['id' => 2, 'name' => 'Installation', 'slug' => 'installation', 'description' => null, 'color' => '#000', 'position' => 0, 'parent_id' => 1, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => true],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'Untagged', 'slug' => 'untagged', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now()],
+                ['id' => 2, 'title' => 'Tagged', 'slug' => 'tagged', 'user_id' => 1, 'first_post_id' => 2, 'comment_count' => 1, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now()],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Body.</p></t>', 'created_at' => Carbon::now()],
+                ['id' => 2, 'discussion_id' => 2, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Body.</p></t>', 'created_at' => Carbon::now()],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 2, 'tag_id' => 2],
+            ],
+        ]);
+
+        // Warm one-time caches before measuring.
+        $this->fetchForumHtml('/');
+
+        $untagged = $this->countQueriesFor('/d/1-untagged');
+        $tagged = $this->countQueriesFor('/d/2-tagged');
+
+        // A tagged discussion loads its tags (+ their parents) — a small, fixed
+        // overhead, NOT one query per breadcrumb level. Guard against a
+        // per-level N+1 creeping in.
+        $this->assertLessThanOrEqual(
+            4,
+            $tagged - $untagged,
+            'Tagged-discussion query count grew by '.($tagged - $untagged).' — a tag-lineage N+1 may have crept in.'
+        );
+    }
+}

--- a/tests/integration/forum/DiscussionPageTest.php
+++ b/tests/integration/forum/DiscussionPageTest.php
@@ -316,6 +316,29 @@ class DiscussionPageTest extends ForumHtmlTestCase
     }
 
     /**
+     * The discussion is resolved through Flarum's SlugManager, so a non-default
+     * discussion slug driver (here the UTF-8 driver) still resolves the model
+     * and the schema `url` is built from the driver's slug. Guards against the
+     * old `(int)` route-param parsing that assumed an id-prefixed slug.
+     */
+    #[Test]
+    public function discussion_resolves_under_a_non_default_slug_driver(): void
+    {
+        $this->setting('slug_driver_Flarum\\Discussion\\Discussion', 'utf8');
+
+        $this->seedDiscussion(title: 'How to bake bread', slug: 'how-to-bake-bread');
+
+        // The UTF-8 driver still id-prefixes, so the URL resolves by id.
+        $html = $this->fetchForumHtml('/d/1-how-to-bake-bread');
+
+        $entry = $this->findSchemaEntry($html, 'DiscussionForumPosting');
+        $this->assertNotNull($entry, 'Expected a DiscussionForumPosting entry under the utf8 slug driver.');
+
+        // The URL is built from the driver's slug (id + transliterated title).
+        $this->assertSame('http://localhost/d/1-how-to-bake-bread', $entry['url'] ?? null);
+    }
+
+    /**
      * When the discussion starter has been deleted there is no profile page to
      * link, so the `DiscussionForumPosting` `author` is omitted rather than
      * emitted without a `url`. This is the exact field Search Console flagged:

--- a/tests/integration/forum/ProfilePageTest.php
+++ b/tests/integration/forum/ProfilePageTest.php
@@ -203,4 +203,42 @@ class ProfilePageTest extends ForumHtmlTestCase
         // Flarum renders 404 for missing users; we just need to be sure no 500.
         $this->assertContains($response->getStatusCode(), [200, 404]);
     }
+
+    /**
+     * With the id-with-display-name user slug driver the profile URL is
+     * `/u/{id}-{name}`. The driver must resolve the user through Flarum's
+     * SlugManager — not assume the route param is a username — otherwise the
+     * page emits no SEO at all (the bug this guards).
+     */
+    #[Test]
+    public function profile_resolves_under_the_id_with_display_name_slug_driver(): void
+    {
+        $this->setting('slug_driver_Flarum\\User\\User', 'id_with_display_name');
+
+        $html = $this->fetchForumHtml('/u/2-victorinox');
+
+        $entry = $this->findSchemaEntry($html, 'ProfilePage');
+        $this->assertNotNull($entry, 'Expected a ProfilePage entry under the id-with-name slug driver.');
+        $this->assertSame('victorinox', $entry['mainEntity']['name'] ?? null);
+
+        // URLs use the driver's slug, not the bare username.
+        $this->assertSame('http://localhost/u/2-victorinox', $this->findMetaByProperty($html, 'og:url'));
+        $this->assertSame('http://localhost/u/2-victorinox', $entry['mainEntity']['url'] ?? null);
+    }
+
+    /**
+     * The id slug driver uses a bare numeric `/u/{id}`.
+     */
+    #[Test]
+    public function profile_resolves_under_the_id_slug_driver(): void
+    {
+        $this->setting('slug_driver_Flarum\\User\\User', 'id');
+
+        $html = $this->fetchForumHtml('/u/2');
+
+        $entry = $this->findSchemaEntry($html, 'ProfilePage');
+        $this->assertNotNull($entry, 'Expected a ProfilePage entry under the id slug driver.');
+        $this->assertSame('victorinox', $entry['mainEntity']['name'] ?? null);
+        $this->assertSame('http://localhost/u/2', $this->findMetaByProperty($html, 'og:url'));
+    }
 }

--- a/tests/integration/forum/SchemaJsonLdTest.php
+++ b/tests/integration/forum/SchemaJsonLdTest.php
@@ -116,18 +116,27 @@ class SchemaJsonLdTest extends ForumHtmlTestCase
             ],
         ]);
 
+        $this->setting('forum_title', 'My Forum');
+
         $html = $this->fetchForumHtml('/d/1-help-bread');
 
         $breadcrumb = $this->findSchemaEntry($html, 'BreadcrumbList');
 
         $this->assertNotNull($breadcrumb, 'Expected a BreadcrumbList entry when tags are present.');
-        $this->assertNotEmpty($breadcrumb['itemListElement'] ?? []);
 
-        $first = $breadcrumb['itemListElement'][0];
-        $this->assertSame('ListItem', $first['@type']);
-        $this->assertSame(1, $first['position']);
-        $this->assertSame('Baking', $first['item']['name'] ?? null);
-        $this->assertSame('http://localhost/t/baking', $first['item']['url'] ?? null);
+        $items = $breadcrumb['itemListElement'] ?? [];
+        // Home › Tags › Baking › {discussion title}.
+        $names = array_column($items, 'name');
+        $this->assertSame(['My Forum', 'Tags', 'Baking', 'Help with bread'], $names);
+
+        // Positions are sequential from 1.
+        $this->assertSame([1, 2, 3, 4], array_column($items, 'position'));
+
+        // The tag crumb links to the tag page...
+        $this->assertSame('http://localhost/t/baking', $items[2]['item']['url'] ?? null);
+        // ...and the last crumb (the discussion) omits `item` so Google uses
+        // the page URL.
+        $this->assertArrayNotHasKey('item', $items[3]);
     }
 
     #[Test]

--- a/tests/unit/Breadcrumb/BreadcrumbTrailTest.php
+++ b/tests/unit/Breadcrumb/BreadcrumbTrailTest.php
@@ -1,0 +1,204 @@
+<?php
+
+/*
+ * This file is part of fof/seo.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Seo\Tests\unit\Breadcrumb;
+
+use FoF\Seo\Breadcrumb\BreadcrumbTrail;
+use FoF\Seo\Breadcrumb\Crumb;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class BreadcrumbTrailTest extends TestCase
+{
+    private function trail(Crumb ...$crumbs): BreadcrumbTrail
+    {
+        $trail = new BreadcrumbTrail();
+
+        foreach ($crumbs as $crumb) {
+            $trail->push($crumb);
+        }
+
+        return $trail;
+    }
+
+    #[Test]
+    public function a_trail_with_fewer_than_two_crumbs_renders_to_null(): void
+    {
+        $this->assertNull((new BreadcrumbTrail())->toSchema());
+        $this->assertNull($this->trail(new Crumb('Home', 'https://f.tld/'))->toSchema());
+    }
+
+    #[Test]
+    public function it_renders_a_breadcrumb_list_with_sequential_positions(): void
+    {
+        $schema = $this->trail(
+            new Crumb('Home', 'https://f.tld/'),
+            new Crumb('Support', 'https://f.tld/t/support'),
+            new Crumb('How do I?')
+        )->toSchema();
+
+        $this->assertSame('https://schema.org', $schema['@context']);
+        $this->assertSame('BreadcrumbList', $schema['@type']);
+
+        $items = $schema['itemListElement'];
+        $this->assertCount(3, $items);
+        $this->assertSame([1, 2, 3], array_column($items, 'position'));
+        $this->assertSame(['Home', 'Support', 'How do I?'], array_column($items, 'name'));
+    }
+
+    #[Test]
+    public function the_last_crumb_omits_item_so_google_uses_the_page_url(): void
+    {
+        $items = $this->trail(
+            new Crumb('Home', 'https://f.tld/'),
+            new Crumb('Current page', 'https://f.tld/current')
+        )->toSchema()['itemListElement'];
+
+        // First crumb carries a full item...
+        $this->assertArrayHasKey('item', $items[0]);
+        $this->assertSame('https://f.tld/', $items[0]['item']['@id']);
+        $this->assertSame('https://f.tld/', $items[0]['item']['url']);
+
+        // ...the last omits it even though a url was provided.
+        $this->assertArrayNotHasKey('item', $items[1]);
+        $this->assertSame('Current page', $items[1]['name']);
+    }
+
+    #[Test]
+    public function a_non_last_crumb_without_a_url_also_omits_item(): void
+    {
+        $items = $this->trail(
+            new Crumb('Home', 'https://f.tld/'),
+            new Crumb('Unlinked section'),       // no url, not last
+            new Crumb('Leaf', 'https://f.tld/x')
+        )->toSchema()['itemListElement'];
+
+        $this->assertArrayNotHasKey('item', $items[1]);
+        $this->assertSame('Unlinked section', $items[1]['name']);
+    }
+
+    #[Test]
+    public function it_does_not_emit_the_legacy_unordered_order_or_count_fields(): void
+    {
+        $schema = $this->trail(
+            new Crumb('Home', 'https://f.tld/'),
+            new Crumb('Leaf', 'https://f.tld/x')
+        )->toSchema();
+
+        $this->assertArrayNotHasKey('itemListOrder', $schema);
+        $this->assertArrayNotHasKey('numberOfItems', $schema);
+    }
+
+    #[Test]
+    public function item_type_defaults_to_webpage_and_is_overridable(): void
+    {
+        $items = $this->trail(
+            new Crumb('Home', 'https://f.tld/'),
+            new Crumb('Cat', 'https://f.tld/c', 'CollectionPage'),
+            new Crumb('Leaf')
+        )->toSchema()['itemListElement'];
+
+        $this->assertSame('WebPage', $items[0]['item']['@type']);
+        $this->assertSame('CollectionPage', $items[1]['item']['@type']);
+    }
+
+    #[Test]
+    public function extra_properties_are_merged_into_the_item(): void
+    {
+        $items = $this->trail(
+            new Crumb('Home', 'https://f.tld/', 'WebPage', ['image' => 'https://f.tld/logo.png']),
+            new Crumb('Leaf', 'https://f.tld/x')
+        )->toSchema()['itemListElement'];
+
+        $this->assertSame('https://f.tld/logo.png', $items[0]['item']['image']);
+    }
+
+    #[Test]
+    public function prepend_adds_to_the_front(): void
+    {
+        $names = array_column(
+            $this->trail(new Crumb('Leaf', 'https://f.tld/x'), new Crumb('End'))
+                ->prepend(new Crumb('Home', 'https://f.tld/'))
+                ->toSchema()['itemListElement'],
+            'name'
+        );
+
+        $this->assertSame(['Home', 'Leaf', 'End'], $names);
+    }
+
+    #[Test]
+    public function insert_after_places_a_crumb_after_the_match(): void
+    {
+        $names = array_column(
+            $this->trail(
+                new Crumb('Home', 'https://f.tld/'),
+                new Crumb('Leaf', 'https://f.tld/x'),
+                new Crumb('End')
+            )
+                ->insertAfter(fn (Crumb $c) => $c->name === 'Home', new Crumb('Mid', 'https://f.tld/m'))
+                ->toSchema()['itemListElement'],
+            'name'
+        );
+
+        $this->assertSame(['Home', 'Mid', 'Leaf', 'End'], $names);
+    }
+
+    #[Test]
+    public function insert_after_appends_when_no_match(): void
+    {
+        $trail = $this->trail(new Crumb('Home', 'https://f.tld/'), new Crumb('Leaf'))
+            ->insertAfter(fn (Crumb $c) => $c->name === 'Nope', new Crumb('Added', 'https://f.tld/a'));
+
+        $this->assertSame(['Home', 'Leaf', 'Added'], array_map(fn (Crumb $c) => $c->name, $trail->all()));
+    }
+
+    #[Test]
+    public function remove_drops_matching_crumbs(): void
+    {
+        $names = array_column(
+            $this->trail(
+                new Crumb('Home', 'https://f.tld/'),
+                new Crumb('Q&A', 'https://f.tld/t/qa'),
+                new Crumb('Leaf')
+            )
+                ->remove(fn (Crumb $c) => $c->name === 'Q&A')
+                ->toSchema()['itemListElement'],
+            'name'
+        );
+
+        $this->assertSame(['Home', 'Leaf'], $names);
+    }
+
+    #[Test]
+    public function map_transforms_crumbs(): void
+    {
+        $items = $this->trail(
+            new Crumb('home', 'https://f.tld/'),
+            new Crumb('leaf', 'https://f.tld/x')
+        )
+            ->map(fn (Crumb $c) => new Crumb(ucfirst($c->name), $c->url))
+            ->toSchema()['itemListElement'];
+
+        $this->assertSame('Home', $items[0]['name']);
+    }
+
+    #[Test]
+    public function count_and_is_empty_reflect_the_trail(): void
+    {
+        $trail = new BreadcrumbTrail();
+        $this->assertTrue($trail->isEmpty());
+        $this->assertSame(0, $trail->count());
+
+        $trail->push(new Crumb('Home', 'https://f.tld/'));
+        $this->assertFalse($trail->isEmpty());
+        $this->assertSame(1, $trail->count());
+    }
+}

--- a/tests/unit/Breadcrumb/TagBreadcrumbTest.php
+++ b/tests/unit/Breadcrumb/TagBreadcrumbTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * This file is part of fof/seo.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Seo\Tests\unit\Breadcrumb;
+
+use Flarum\Http\RouteCollectionUrlGenerator;
+use Flarum\Http\UrlGenerator;
+use Flarum\Tags\Tag;
+use FoF\Seo\Breadcrumb\Crumb;
+use FoF\Seo\Breadcrumb\TagBreadcrumb;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class TagBreadcrumbTest extends TestCase
+{
+    private function tagBreadcrumb(): TagBreadcrumb
+    {
+        // A UrlGenerator whose route() just echoes a predictable path; the
+        // lineage logic under test cares about which tags/order, not the URLs.
+        $routes = $this->createStub(RouteCollectionUrlGenerator::class);
+        $routes->method('route')->willReturnCallback(
+            fn (string $name, array $params = []) => 'https://f.tld/'.$name.(isset($params['slug']) ? '/'.$params['slug'] : '')
+        );
+
+        $url = $this->createStub(UrlGenerator::class);
+        $url->method('to')->willReturn($routes);
+
+        return new TagBreadcrumb($url);
+    }
+
+    /**
+     * Build a Tag without touching the database. `parent` is wired as a loaded
+     * relation so lineage() walks it without a query.
+     */
+    private function tag(int $id, string $name, bool $primary, ?Tag $parent = null): Tag
+    {
+        $tag = new Tag();
+        $tag->id = $id;
+        $tag->name = $name;
+        $tag->slug = strtolower($name);
+        $tag->is_primary = $primary;
+        $tag->parent_id = $parent?->id;
+        $tag->setRelation('parent', $parent);
+
+        return $tag;
+    }
+
+    /**
+     * @param list<Crumb> $lineage
+     *
+     * @return list<string>
+     */
+    private function names(array $lineage): array
+    {
+        return array_map(fn (Crumb $c) => $c->name, $lineage);
+    }
+
+    #[Test]
+    public function no_primary_tags_yields_no_lineages(): void
+    {
+        $tags = new Collection([
+            $this->tag(1, 'Announcements', false),
+            $this->tag(2, 'Off-topic', false),
+        ]);
+
+        $this->assertSame([], $this->tagBreadcrumb()->primaryLineages($tags));
+    }
+
+    #[Test]
+    public function a_single_primary_tag_yields_one_lineage(): void
+    {
+        $tags = new Collection([$this->tag(1, 'Support', true)]);
+
+        $lineages = $this->tagBreadcrumb()->primaryLineages($tags);
+
+        $this->assertCount(1, $lineages);
+        $this->assertSame(['Tags', 'Support'], $this->names($lineages[0]));
+    }
+
+    #[Test]
+    public function a_primary_parent_and_child_fold_into_one_lineage(): void
+    {
+        $support = $this->tag(1, 'Support', true);
+        $install = $this->tag(2, 'Installation', true, $support);
+
+        // Both attached; order shouldn't matter.
+        $lineages = $this->tagBreadcrumb()->primaryLineages(new Collection([$support, $install]));
+
+        $this->assertCount(1, $lineages);
+        $this->assertSame(['Tags', 'Support', 'Installation'], $this->names($lineages[0]));
+    }
+
+    #[Test]
+    public function a_child_attached_without_its_parent_still_lists_ancestors(): void
+    {
+        $support = $this->tag(1, 'Support', true);
+        $install = $this->tag(2, 'Installation', true, $support);
+
+        // Only the child is attached; its ancestor must still appear.
+        $lineages = $this->tagBreadcrumb()->primaryLineages(new Collection([$install]));
+
+        $this->assertCount(1, $lineages);
+        $this->assertSame(['Tags', 'Support', 'Installation'], $this->names($lineages[0]));
+    }
+
+    #[Test]
+    public function two_unrelated_primary_tags_yield_two_lineages(): void
+    {
+        $lineages = $this->tagBreadcrumb()->primaryLineages(new Collection([
+            $this->tag(1, 'Support', true),
+            $this->tag(2, 'Bugs', true),
+        ]));
+
+        $this->assertCount(2, $lineages);
+        $this->assertSame(['Tags', 'Support'], $this->names($lineages[0]));
+        $this->assertSame(['Tags', 'Bugs'], $this->names($lineages[1]));
+    }
+
+    #[Test]
+    public function secondary_tags_are_excluded_when_mixed_with_a_primary(): void
+    {
+        $lineages = $this->tagBreadcrumb()->primaryLineages(new Collection([
+            $this->tag(1, 'Chatter', false),
+            $this->tag(2, 'Support', true),
+        ]));
+
+        $this->assertCount(1, $lineages);
+        $this->assertSame(['Tags', 'Support'], $this->names($lineages[0]));
+    }
+}


### PR DESCRIPTION
Replaces the flat, unordered tag-list breadcrumb with proper schema.org `BreadcrumbList` trails.

## Trails by layer

- **Core pages:** `Home › {title}` for discussions, profiles and fof/pages pages.
- **flarum/tags:** `Home › Tags › {primary tag lineage} › {title}`, walking the primary tag's ancestry. Only **primary** tags form a path; secondary tags are excluded. A discussion in multiple unrelated primary tags emits one `BreadcrumbList` per lineage. Adds page drivers for `/tags` and (when fof/user-directory is enabled) `/users`.
- **Extensions:** fof/best-answer (QAPage) and fof/pages get trails through the same system.

## Correctness

- Spec-correct output: ≥2 items, sequential `position`, the current page's `item` omitted (Google uses the page URL), and the legacy `itemListOrder: ItemListUnordered`/`numberOfItems` dropped.
- The configured forum home (`default_route`) emits no breadcrumb of its own.

## Extensibility

- Drivers build trails via `$properties->breadcrumb()` / `newBreadcrumb()` / `addBreadcrumb()`.
- Third parties add/remove/modify crumbs via the new `BuildingBreadcrumb` event.
- The old `generateSchemaBreadcrumb()` is kept as a deprecated shim.

## Slug drivers

Users and discussions are now resolved (and their URLs built) through Flarum's `SlugManager` instead of assuming a username/id route param. Previously a non-default user slug driver (`id`, `id_with_display_name`) caused profile pages to emit **no SEO at all**; discussion SEO would likewise break under a custom slug driver. Covered for the username/id/id-with-name (users) and default/utf8 (discussions) drivers.

`flarum/markdown` and `fof/user-directory` added as dev/optional dependencies for test coverage.

Verified on a live forum (which uses the id-with-name slug driver) across discussion, tag, /tags and profile pages.