### PR TITLE
[2.x] Always emit author on forum/Q&A nodes; emit only valid image/answer fields

### DIFF
--- a/src/Page/DiscussionBestAnswerPage.php
+++ b/src/Page/DiscussionBestAnswerPage.php
@@ -23,11 +23,11 @@ use Flarum\Post\CommentPost;
 use Flarum\Post\Post;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Tags\Tag;
-use Flarum\User\User;
 use Flarum\User\UserRepository;
 use FoF\Seo\Breadcrumb\TagBreadcrumb;
 use FoF\Seo\SeoMeta\SeoMeta;
 use FoF\Seo\SeoProperties;
+use FoF\Seo\Support\AuthorSchema;
 use FoF\Seo\Support\PostMedia;
 use FoF\Seo\TagIndexingPolicy;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -49,32 +49,9 @@ class DiscussionBestAnswerPage implements PageDriverInterface
         Dispatcher $events,
         protected readonly SlugManager $slugManager,
         protected readonly TagIndexingPolicy $tagIndexingPolicy,
+        protected readonly AuthorSchema $authorSchema,
     ) {
         $this->events = $events;
-    }
-
-    /**
-     * Build a schema.org Person for a question/answer author, or null when the
-     * user has been deleted. Google's QAPage guidance expects `author.url` to
-     * be "a link to a web page that uniquely identifies the author" — a profile
-     * page. A deleted user has no such page, and emitting an `author` Person
-     * without a `url` trips Search Console's "Missing field 'url' (in
-     * 'mainEntity.author')". Since `author` is recommended rather than required,
-     * callers omit it entirely when this returns null (GH #140).
-     *
-     * @return array<string, string>|null
-     */
-    private function authorSchema(?User $user): ?array
-    {
-        if ($user === null) {
-            return null;
-        }
-
-        return [
-            '@type' => 'Person',
-            'name'  => $user->getDisplayNameAttribute(),
-            'url'   => $this->urlGenerator->to('forum')->route('user', ['username' => $this->slugManager->forResource(User::class)->toSlug($user)]),
-        ];
     }
 
     public function extensionDependencies(): array
@@ -195,17 +172,22 @@ class DiscussionBestAnswerPage implements PageDriverInterface
             'answerCount' => $discussion->comment_count - 1,
         ];
 
-        // text/image/video for the question (its first post). Google's "Either
-        // 'text', 'image' or 'video' should be specified" applies here too, so
-        // emit whichever the post actually has rather than an empty `text`.
-        if ($firstPost instanceof CommentPost) {
-            $mainEntity += PostMedia::schemaFields($firstPost->formatContent());
+        // text/image/video for the question (its first post).
+        $questionMedia = $firstPost instanceof CommentPost
+            ? PostMedia::schemaFields($firstPost->formatContent())
+            : [];
+
+        // Drop `text` when it merely repeats the question `name` — Google
+        // rejects identical sibling values ("unique values are required").
+        if (($questionMedia['text'] ?? null) === $mainEntity['name']) {
+            unset($questionMedia['text']);
         }
 
-        // Omit `author` when the starter is deleted — see authorSchema().
-        if (($questionAuthor = $this->authorSchema($discussion->user)) !== null) {
-            $mainEntity['author'] = $questionAuthor;
-        }
+        $mainEntity += $questionMedia;
+
+        // `author` is required on the Question; AuthorSchema yields a
+        // "[deleted]" Person for a removed starter rather than omitting it.
+        $mainEntity['author'] = $this->authorSchema->forUser($discussion->user);
 
         // Upvotes on the question itself (the first post), when likes are available.
         if ($enableLikes && $firstPost !== null) {
@@ -255,10 +237,10 @@ class DiscussionBestAnswerPage implements PageDriverInterface
                 'url'         => $this->urlGenerator->to('forum')->route('discussion', ['id' => $discussionSlug, 'near' => $post->number]),
             ] + PostMedia::schemaFields($post->formatContent());
 
-            // Omit `author` when this post's user is deleted — see authorSchema().
-            if (($answerAuthor = $this->authorSchema($post->user)) !== null) {
-                $generatedPost['author'] = $answerAuthor;
-            }
+            // `author` is recommended on an Answer; AuthorSchema yields a
+            // "[deleted]" Person for a removed user (with a name, so the
+            // `author.name` requirement is met) rather than omitting it.
+            $generatedPost['author'] = $this->authorSchema->forUser($post->user);
 
             // Upvote/like count
             $generatedPost['upvoteCount'] = $enableLikes ? $post->likes->count() : 0;
@@ -267,8 +249,10 @@ class DiscussionBestAnswerPage implements PageDriverInterface
             if ($bestAnswerId === $post->id) {
                 $mainEntity['acceptedAnswer'] = $generatedPost;
             }
-            // Add to answers
-            else {
+            // Add to answers — but only when the answer has the content an
+            // Answer requires (text/image/video). A contentless suggested
+            // answer would trip "Missing field 'text' (in suggestedAnswer)".
+            elseif (isset($generatedPost['text']) || isset($generatedPost['image']) || isset($generatedPost['video'])) {
                 $mainEntity['suggestedAnswer'][] = $generatedPost;
             }
         }

--- a/src/Page/DiscussionPage.php
+++ b/src/Page/DiscussionPage.php
@@ -23,11 +23,11 @@ use Flarum\Post\CommentPost;
 use Flarum\Post\Post;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Tags\Tag;
-use Flarum\User\User;
 use Flarum\User\UserRepository;
 use FoF\Seo\Breadcrumb\TagBreadcrumb;
 use FoF\Seo\SeoMeta\SeoMeta;
 use FoF\Seo\SeoProperties;
+use FoF\Seo\Support\AuthorSchema;
 use FoF\Seo\Support\PostMedia;
 use FoF\Seo\TagIndexingPolicy;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -49,32 +49,9 @@ class DiscussionPage implements PageDriverInterface
         Dispatcher $events,
         protected readonly SlugManager $slugManager,
         protected readonly TagIndexingPolicy $tagIndexingPolicy,
+        protected readonly AuthorSchema $authorSchema,
     ) {
         $this->events = $events;
-    }
-
-    /**
-     * Build a schema.org Person for a post/discussion author, or null when the
-     * user has been deleted. Google's forum guidance expects `author.url` to
-     * link to a page identifying the author (a profile page). A deleted user
-     * has no such page, and emitting an `author` Person without a `url` trips
-     * Search Console's "Missing field 'url' (in 'author')". Since `author` is
-     * recommended rather than required, callers omit it entirely when this
-     * returns null (GH #140).
-     *
-     * @return array<string, string>|null
-     */
-    private function authorSchema(?User $user): ?array
-    {
-        if ($user === null) {
-            return null;
-        }
-
-        return [
-            '@type' => 'Person',
-            'name'  => $user->getDisplayNameAttribute(),
-            'url'   => $this->urlGenerator->to('forum')->route('user', ['username' => $this->slugManager->forResource(User::class)->toSlug($user)]),
-        ];
     }
 
     /**
@@ -109,10 +86,9 @@ class DiscussionPage implements PageDriverInterface
             'url'           => $this->urlGenerator->to('forum')->route('discussion', ['id' => $this->slugManager->forResource(FlarumDiscussion::class)->toSlug($discussion), 'near' => $post->number]),
         ] + $media;
 
-        // Omit `author` when the commenter is deleted — see authorSchema().
-        if (($commentAuthor = $this->authorSchema($post->user)) !== null) {
-            $comment['author'] = $commentAuthor;
-        }
+        // `author` is required on a Comment; AuthorSchema yields a "[deleted]"
+        // Person for a removed user rather than omitting it.
+        $comment['author'] = $this->authorSchema->forUser($post->user);
 
         if ($enableLikes || $enableGamification) {
             $count = 0;
@@ -334,10 +310,9 @@ class DiscussionPage implements PageDriverInterface
         }
 
         // author: https://schema.org/author typeof: https://schema.org/Person.
-        // Omit `author` when the starter is deleted — see authorSchema() (#140).
-        if (($discussionAuthor = $this->authorSchema($discussion->user)) !== null) {
-            $properties->setSchemaJson('author', $discussionAuthor);
-        }
+        // REQUIRED on DiscussionForumPosting — a deleted starter still yields a
+        // "[deleted]" Person (no url) rather than omitting the field.
+        $properties->setSchemaJson('author', $this->authorSchema->forUser($discussion->user));
 
         // Breadcrumb: Home › Tags › {primary lineage} › {discussion title}. Each
         // distinct primary-tag lineage produces its own trail; secondary tags

--- a/src/Support/AuthorSchema.php
+++ b/src/Support/AuthorSchema.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of fof/seo.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Seo\Support;
+
+use Flarum\Http\SlugManager;
+use Flarum\Http\UrlGenerator;
+use Flarum\User\User;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Builds the schema.org Person for a post/discussion author.
+ *
+ * `author` (and `author.name`) are REQUIRED on DiscussionForumPosting and on
+ * each Comment — omitting them is a critical error that blocks rich results.
+ * So a deleted user still yields a Person, named with the localized "[deleted]"
+ * label, just without a profile `url` (which is only recommended, and which a
+ * removed account no longer has). This keeps the markup GDPR-safe — "[deleted]"
+ * carries no personal data — while satisfying Google's required fields.
+ */
+class AuthorSchema
+{
+    public function __construct(
+        private readonly UrlGenerator $url,
+        private readonly SlugManager $slugManager,
+        private readonly TranslatorInterface $translator,
+    ) {
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function forUser(?User $user): array
+    {
+        if ($user === null) {
+            return [
+                '@type' => 'Person',
+                'name'  => $this->translator->trans('core.lib.username.deleted_text'),
+            ];
+        }
+
+        return [
+            '@type' => 'Person',
+            'name'  => $user->getDisplayNameAttribute(),
+            'url'   => $this->url->to('forum')->route('user', [
+                'username' => $this->slugManager->forResource(User::class)->toSlug($user),
+            ]),
+        ];
+    }
+}

--- a/src/Support/PostMedia.php
+++ b/src/Support/PostMedia.php
@@ -115,11 +115,19 @@ class PostMedia
         foreach ($matches[2] as $url) {
             $url = html_entity_decode($url, ENT_QUOTES | ENT_HTML5);
 
-            if ($url !== '' && !in_array($url, $urls, true)) {
+            // Only emit absolute http(s) URLs. Google rejects relative,
+            // protocol-relative (`//host`), `data:` and `blob:` sources as an
+            // "Invalid URL" in schema.org image/video fields.
+            if (self::isAbsoluteHttpUrl($url) && !in_array($url, $urls, true)) {
                 $urls[] = $url;
             }
         }
 
         return $urls;
+    }
+
+    private static function isAbsoluteHttpUrl(string $url): bool
+    {
+        return (bool) preg_match('#^https?://#i', $url);
     }
 }

--- a/tests/integration/forum/BestAnswerPageTest.php
+++ b/tests/integration/forum/BestAnswerPageTest.php
@@ -171,15 +171,12 @@ class BestAnswerPageTest extends ForumHtmlTestCase
     }
 
     /**
-     * Google's QAPage guidance says `author.url` should be "a link to a web
-     * page that uniquely identifies the author" — a profile page. A deleted
-     * user has no such page, so emitting an `author` Person without a `url`
-     * trips Search Console's "Missing field 'url' (in 'mainEntity.author')".
-     * `author` is recommended, not required, so we omit it entirely when the
-     * user is gone rather than emit an incomplete Person (GH #140).
+     * A deleted answer author still yields a "[deleted]" Person (with a name,
+     * no url) rather than omitting `author` — `author.name` is required, and an
+     * omitted author trips "Missing field 'author' (in suggestedAnswer)".
      */
     #[Test]
-    public function answer_by_deleted_user_omits_the_author(): void
+    public function answer_by_deleted_user_still_has_a_named_author(): void
     {
         $this->setting('seo_post_crawler', '1');
 
@@ -204,21 +201,19 @@ class BestAnswerPageTest extends ForumHtmlTestCase
 
         $accepted = $this->findSchemaEntry($this->fetchForumHtml('/d/1-how-do-i-bake-bread'), 'QAPage')['mainEntity']['acceptedAnswer'] ?? [];
 
-        // The answer itself is still emitted...
         $this->assertSame('Answer', $accepted['@type'] ?? null);
-        // ...but with no `author`, since there is no profile to link to.
-        $this->assertArrayNotHasKey('author', $accepted);
+        // author present: Person with a name, no url.
+        $this->assertSame('Person', $accepted['author']['@type'] ?? null);
+        $this->assertNotEmpty($accepted['author']['name'] ?? null);
+        $this->assertArrayNotHasKey('url', $accepted['author']);
     }
 
     /**
-     * The question author (`mainEntity.author`) follows the same rule: when the
-     * discussion starter has been deleted there is no profile page to link, so
-     * the `author` object is omitted rather than emitted without a `url`. This
-     * is the exact field Search Console flagged: "Missing field 'url' (in
-     * 'mainEntity.author')".
+     * The question author (`mainEntity.author`) follows the same rule: a
+     * deleted starter still yields a "[deleted]" Person (name, no url).
      */
     #[Test]
-    public function question_by_deleted_user_omits_the_author(): void
+    public function question_by_deleted_user_still_has_a_named_author(): void
     {
         $this->setting('seo_post_crawler', '1');
 
@@ -244,7 +239,10 @@ class BestAnswerPageTest extends ForumHtmlTestCase
         $question = $this->findSchemaEntry($this->fetchForumHtml('/d/1-how-do-i-bake-bread'), 'QAPage')['mainEntity'] ?? [];
 
         $this->assertSame('Question', $question['@type'] ?? null);
-        $this->assertArrayNotHasKey('author', $question);
+        // author present: Person with a name, no url.
+        $this->assertSame('Person', $question['author']['@type'] ?? null);
+        $this->assertNotEmpty($question['author']['name'] ?? null);
+        $this->assertArrayNotHasKey('url', $question['author']);
     }
 
     /**
@@ -393,6 +391,79 @@ class BestAnswerPageTest extends ForumHtmlTestCase
         // ...and the image stands in for the absent text.
         $this->assertArrayNotHasKey('text', $question);
         $this->assertSame('https://example.com/q.png', $question['image'] ?? null);
+    }
+
+    /**
+     * When the question body renders to the same string as the title, the
+     * `text` is dropped so it doesn't duplicate `name` — Google rejects
+     * identical sibling values ("unique values are required (in mainEntity)").
+     */
+    #[Test]
+    public function question_text_equal_to_name_is_dropped(): void
+    {
+        $this->setting('seo_post_crawler', '1');
+
+        $now = Carbon::now();
+
+        $this->prepareDatabase([
+            Tag::class => [
+                ['id' => self::QNA_TAG_ID, 'name' => 'Questions', 'slug' => 'questions', 'description' => null, 'color' => '#000', 'position' => 0, 'is_restricted' => false, 'is_hidden' => false, 'is_qna' => true],
+            ],
+            Discussion::class => [
+                // Title equals the first post body once rendered to plain text.
+                ['id' => 1, 'title' => 'Is it broken?', 'slug' => 'is-it-broken', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 2, 'best_answer_post_id' => 2, 'created_at' => $now, 'last_posted_at' => $now],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Is it broken?</p></t>', 'created_at' => $now],
+                ['id' => 2, 'discussion_id' => 1, 'number' => 2, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Yes.</p></t>', 'created_at' => $now],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => self::QNA_TAG_ID],
+            ],
+        ]);
+
+        $question = $this->findSchemaEntry($this->fetchForumHtml('/d/1-is-it-broken'), 'QAPage')['mainEntity'] ?? [];
+
+        $this->assertSame('Is it broken?', $question['name'] ?? null);
+        // text is omitted because it would equal name.
+        $this->assertArrayNotHasKey('text', $question);
+    }
+
+    /**
+     * A suggested answer that renders to no text/image/video can't form a valid
+     * Answer node, so it's dropped rather than emitted without `text` ("Missing
+     * field 'text' (in suggestedAnswer)"). The accepted answer is unaffected.
+     */
+    #[Test]
+    public function contentless_suggested_answer_is_dropped(): void
+    {
+        $this->setting('seo_post_crawler', '1');
+
+        $now = Carbon::now();
+
+        $this->prepareDatabase([
+            Tag::class => [
+                ['id' => self::QNA_TAG_ID, 'name' => 'Questions', 'slug' => 'questions', 'description' => null, 'color' => '#000', 'position' => 0, 'is_restricted' => false, 'is_hidden' => false, 'is_qna' => true],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'How do I bake bread?', 'slug' => 'how-do-i-bake-bread', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 3, 'best_answer_post_id' => 2, 'created_at' => $now, 'last_posted_at' => $now],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>How?</p></t>', 'created_at' => $now],
+                ['id' => 2, 'discussion_id' => 1, 'number' => 2, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Use flour.</p></t>', 'created_at' => $now],
+                // Suggested answer that renders to nothing.
+                ['id' => 3, 'discussion_id' => 1, 'number' => 3, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p> </p></t>', 'created_at' => $now],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => self::QNA_TAG_ID],
+            ],
+        ]);
+
+        $question = $this->findSchemaEntry($this->fetchForumHtml('/d/1-how-do-i-bake-bread'), 'QAPage')['mainEntity'] ?? [];
+
+        // Accepted answer present; the empty suggested answer is dropped.
+        $this->assertArrayHasKey('text', $question['acceptedAnswer'] ?? []);
+        $this->assertSame([], $question['suggestedAnswer'] ?? ['x']);
     }
 
     /**

--- a/tests/integration/forum/DiscussionCommentsTest.php
+++ b/tests/integration/forum/DiscussionCommentsTest.php
@@ -110,15 +110,12 @@ class DiscussionCommentsTest extends ForumHtmlTestCase
      * dominant page-load cost, so the cap bounds it.
      */
     /**
-     * Google's forum guidance says `author.url` should link to a page that
-     * identifies the author (a profile page). A deleted user has no such page,
-     * so emitting an `author` Person without a `url` trips Search Console's
-     * "Missing field 'url' (in 'author')". `author` is recommended, not
-     * required, so we omit it entirely for a deleted user rather than emit an
-     * incomplete Person (GH #140).
+     * `author` is REQUIRED on a schema.org Comment. A reply by a deleted user
+     * must still emit a "[deleted]" Person (with a name, no url) rather than
+     * omitting `author` — omission is a critical error.
      */
     #[Test]
-    public function comment_by_deleted_user_omits_the_author(): void
+    public function comment_by_deleted_user_still_has_a_named_author(): void
     {
         $this->prepareDatabase([
             User::class => [
@@ -138,10 +135,11 @@ class DiscussionCommentsTest extends ForumHtmlTestCase
 
         $comment = $entry['comment'][0] ?? null;
         $this->assertIsArray($comment);
-        // The comment itself is still emitted...
         $this->assertSame('Comment', $comment['@type'] ?? null);
-        // ...but with no `author`, since a deleted user has no profile to link.
-        $this->assertArrayNotHasKey('author', $comment);
+        // author present: a Person with a name, no url.
+        $this->assertSame('Person', $comment['author']['@type'] ?? null);
+        $this->assertNotEmpty($comment['author']['name'] ?? null);
+        $this->assertArrayNotHasKey('url', $comment['author']);
     }
 
     #[Test]

--- a/tests/integration/forum/DiscussionPageTest.php
+++ b/tests/integration/forum/DiscussionPageTest.php
@@ -339,14 +339,14 @@ class DiscussionPageTest extends ForumHtmlTestCase
     }
 
     /**
-     * When the discussion starter has been deleted there is no profile page to
-     * link, so the `DiscussionForumPosting` `author` is omitted rather than
-     * emitted without a `url`. This is the exact field Search Console flagged:
-     * "Missing field 'url' (in 'author')". `author` is recommended, not
-     * required, so omission is valid (GH #140).
+     * `author` (and `author.name`) are REQUIRED on DiscussionForumPosting —
+     * omitting them is a critical error that blocks rich results. When the
+     * starter has been deleted we still emit a "[deleted]" Person, just without
+     * a profile `url` (which a removed account no longer has). Locks the fix for
+     * the critical "Missing field 'author'" Search Console error.
      */
     #[Test]
-    public function discussion_by_deleted_user_omits_the_author(): void
+    public function discussion_by_deleted_user_still_has_a_named_author(): void
     {
         $this->prepareDatabase([
             Discussion::class => [
@@ -361,7 +361,10 @@ class DiscussionPageTest extends ForumHtmlTestCase
         $entry = $this->findSchemaEntry($this->fetchForumHtml('/d/1-orphaned'), 'DiscussionForumPosting');
 
         $this->assertNotNull($entry, 'Expected a DiscussionForumPosting JSON-LD entry.');
-        $this->assertArrayNotHasKey('author', $entry);
+        // author is present, a Person, with a non-empty name and no url.
+        $this->assertSame('Person', $entry['author']['@type'] ?? null);
+        $this->assertNotEmpty($entry['author']['name'] ?? null);
+        $this->assertArrayNotHasKey('url', $entry['author']);
     }
 
     /**

--- a/tests/unit/Support/AuthorSchemaTest.php
+++ b/tests/unit/Support/AuthorSchemaTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of fof/seo.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Seo\Tests\unit\Support;
+
+use Flarum\Http\SlugManager;
+use Flarum\Http\UrlGenerator;
+use FoF\Seo\Support\AuthorSchema;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class AuthorSchemaTest extends TestCase
+{
+    private function authorSchema(): AuthorSchema
+    {
+        // The deleted-user branch never builds a URL, so url/slug collaborators
+        // are stubbed but not configured.
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturn('[deleted]');
+
+        return new AuthorSchema(
+            $this->createStub(UrlGenerator::class),
+            $this->createStub(SlugManager::class),
+            $translator,
+        );
+    }
+
+    #[Test]
+    public function a_deleted_user_yields_a_named_person_with_no_url(): void
+    {
+        $author = $this->authorSchema()->forUser(null);
+
+        $this->assertSame('Person', $author['@type']);
+        $this->assertSame('[deleted]', $author['name']);
+        // author.name is required; url is not emitted for a removed account.
+        $this->assertArrayNotHasKey('url', $author);
+    }
+
+    // The live-user branch (Person with name + profile url) needs a booted app
+    // for User::getDisplayNameAttribute(), so it's covered by the integration
+    // tests (author_of_a_live_user_carries_a_profile_url and friends).
+}

--- a/tests/unit/Support/PostMediaTest.php
+++ b/tests/unit/Support/PostMediaTest.php
@@ -34,6 +34,32 @@ class PostMediaTest extends TestCase
     }
 
     #[Test]
+    public function non_absolute_image_urls_are_rejected(): void
+    {
+        // Google rejects relative, protocol-relative, data: and blob: URLs as
+        // "Invalid URL" in schema.org image fields.
+        $this->assertSame([], PostMedia::images('<img src="/assets/a.png">'));
+        $this->assertSame([], PostMedia::images('<img src="//cdn.tld/a.png">'));
+        $this->assertSame([], PostMedia::images('<img src="data:image/png;base64,iVBOR">'));
+        $this->assertSame([], PostMedia::images('<img src="a.png">'));
+    }
+
+    #[Test]
+    public function http_and_https_absolute_urls_are_kept(): void
+    {
+        $this->assertSame(['http://x.tld/a.png'], PostMedia::images('<img src="http://x.tld/a.png">'));
+        $this->assertSame(['https://x.tld/b.png'], PostMedia::images('<img src="https://x.tld/b.png">'));
+    }
+
+    #[Test]
+    public function mixed_absolute_and_relative_keeps_only_absolute(): void
+    {
+        $html = '<img src="/rel.png"><img src="https://x.tld/abs.png">';
+
+        $this->assertSame(['https://x.tld/abs.png'], PostMedia::images($html));
+    }
+
+    #[Test]
     public function extracts_a_fof_upload_image_preview(): void
     {
         // The shape fof/upload's image-preview template renders to (the <img>


### PR DESCRIPTION
Search Console reported a **critical** `Missing field 'author'` on DiscussionForumPosting (blocking rich results), plus several Q&A issues.

`author` and `author.name` are **required** on `DiscussionForumPosting` and `Comment`. A previous change (#170) dropped the whole `author` object for deleted users, when it should only have dropped the recommended `url`. This restores `author` for deleted users as a `Person` named "[deleted]" with no `url` — satisfying the required fields while staying GDPR-safe (the "[deleted]" label is not personal data, so it works for users who have exercised their right to erasure).

The author markup is centralised in a new `FoF\Seo\Support\AuthorSchema`, used by both the discussion and Q&A drivers, so the two can no longer drift apart (the original bug came from duplicated logic).

Also addresses, from the same Q&A report:

- **`Identical property values ... unique values are required (in mainEntity)`** — the Question `text` is dropped when it would equal `name`.
- **`Missing field 'text' (in suggestedAnswer)`** — a suggested answer that renders to no text/image/video is dropped rather than emitted without the required `text`.
- **`Invalid URL in field 'image' (in mainEntity)`** — `PostMedia` now emits only absolute `http(s)` URLs; relative, protocol-relative, `data:` and `blob:` sources are skipped.

Corrects #170. Verified against the live forum (deleted-author discussions now carry a "[deleted]" author).

The remaining `Missing field 'url' (in ...author)` Q&A items are the recommended `url` on live authors from pre-#170 crawls and clear on Search Console re-validation.