### PR TITLE
[1.x] fix: emit JSON-LD as @graph root instead of a bare array

### DIFF
--- a/src/Listeners/PageListener.php
+++ b/src/Listeners/PageListener.php
@@ -183,16 +183,34 @@ class PageListener
      */
     private function writeSchemesOrgJson(): string
     {
-        $show = [];
-        $show[] = $this->schemaArray;
+        $nodes = [];
+        $nodes[] = $this->schemaArray;
 
         if (count($this->schemaBreadcrumb) > 0) {
-            $show[] = $this->schemaBreadcrumb;
+            $nodes[] = $this->schemaBreadcrumb;
         }
 
-        $show[] = $this->addSearchBar();
+        $nodes[] = $this->addSearchBar();
 
-        return '<script type="application/ld+json">'.json_encode($show).'</script>';
+        // Emit a single root object using `@graph` rather than a bare array of
+        // entities. Some consumers (e.g. Safari's structured-data parser) read
+        // the parsed root and call `root["@context"].toLowerCase()`; when the
+        // root is an array that property is undefined and they throw. A single
+        // `@context` + `@graph` root keeps them happy and is the spec-preferred
+        // way to bundle multiple nodes in one block. The shared root context
+        // makes the per-node `@context` redundant, so drop it from each node.
+        $graph = array_map(static function (array $node): array {
+            unset($node['@context']);
+
+            return $node;
+        }, $nodes);
+
+        $document = [
+            '@context' => 'http://schema.org',
+            '@graph'   => $graph,
+        ];
+
+        return '<script type="application/ld+json">'.json_encode($document).'</script>';
     }
 
     /**

--- a/tests/integration/ForumHtmlTestCase.php
+++ b/tests/integration/ForumHtmlTestCase.php
@@ -91,8 +91,10 @@ abstract class ForumHtmlTestCase extends TestCase
 
     /**
      * Parse the `<script type="application/ld+json">...</script>` block and
-     * return its decoded JSON content. The extension emits a single merged
-     * array, so the returned value is a list of top-level JSON-LD objects.
+     * return the list of schema.org nodes it contains. The extension emits a
+     * single root object with an `@graph` list of nodes (a bare array root
+     * crashes some consumers, e.g. Safari's structured-data parser), so unwrap
+     * `@graph` to the node list. A bare array is still accepted for resilience.
      *
      * @return array<int, array<string, mixed>>|null
      */
@@ -104,8 +106,16 @@ abstract class ForumHtmlTestCase extends TestCase
 
         $decoded = json_decode($matches[1], true);
 
-        // The extension always wraps multiple schema entries in a top-level array.
-        return is_array($decoded) ? $decoded : null;
+        if (!is_array($decoded)) {
+            return null;
+        }
+
+        // Single root object with `@graph` => the nodes live under `@graph`.
+        if (isset($decoded['@graph']) && is_array($decoded['@graph'])) {
+            return $decoded['@graph'];
+        }
+
+        return $decoded;
     }
 
     /**

--- a/tests/integration/forum/SchemaJsonLdTest.php
+++ b/tests/integration/forum/SchemaJsonLdTest.php
@@ -136,6 +136,30 @@ class SchemaJsonLdTest extends ForumHtmlTestCase
     }
 
     /**
+     * The block's root must be a single object carrying a string `@context`
+     * and an `@graph` list — never a bare array. A bare-array root makes
+     * `root["@context"]` undefined, crashing consumers that call
+     * `root["@context"].toLowerCase()` (e.g. Safari's parser). Regression lock.
+     *
+     * @test
+     */
+    public function json_ld_root_is_a_graph_object_not_a_bare_array(): void
+    {
+        $html = $this->fetchForumHtml('/');
+
+        $this->assertSame(1, preg_match('/<script\s+type="application\/ld\+json"[^>]*>(.*?)<\/script>/is', $html, $matches));
+
+        $root = json_decode($matches[1], true);
+
+        $this->assertIsArray($root);
+        $this->assertArrayHasKey('@context', $root, 'Root must carry a top-level @context.');
+        $this->assertIsString($root['@context']);
+        $this->assertArrayHasKey('@graph', $root, 'Root must bundle nodes under @graph.');
+        $this->assertIsArray($root['@graph']);
+        $this->assertArrayNotHasKey(0, $root, 'Root must not be a bare list of nodes.');
+    }
+
+    /**
      * @test
      */
     public function json_ld_block_is_always_valid_json(): void


### PR DESCRIPTION
The JSON-LD block was emitted as a bare top-level array of schema.org objects. Safari's structured-data parser reads the parsed root and calls `root["@context"].toLowerCase()`; an array has no `@context`, so it throws `TypeError: undefined is not an object`.

Emits a single root object with `@context` and an `@graph` list instead. Per-node `@context` is dropped as redundant under the shared root.

Added a regression test pinning the root to an `@graph` object; full integration suite passes (117 tests).

Closes #177
