### PR TITLE
[2.x] Emit JSON-LD as an @graph root instead of a bare array

### DIFF
--- a/src/Listeners/PageListener.php
+++ b/src/Listeners/PageListener.php
@@ -41,7 +41,7 @@ class PageListener
      * @var array<string, mixed>
      */
     protected array $schemaArray = [
-        '@context' => 'http://schema.org',
+        '@context' => 'https://schema.org',
         '@type'    => 'WebPage',
     ];
 
@@ -301,8 +301,8 @@ class PageListener
      */
     private function writeSchemesOrgJson(): string
     {
-        $show = [];
-        $show[] = $this->schemaArray;
+        $graph = [];
+        $graph[] = $this->schemaArray;
 
         // Each trail renders as its own BreadcrumbList (null when it has fewer
         // than two crumbs, e.g. on the forum home).
@@ -310,13 +310,26 @@ class PageListener
             $breadcrumb = $trail->toSchema();
 
             if ($breadcrumb !== null) {
-                $show[] = $breadcrumb;
+                $graph[] = $breadcrumb;
             }
         }
 
-        $show[] = $this->addSearchBar();
+        $graph[] = $this->addSearchBar();
 
-        return '<script type="application/ld+json">'.json_encode($show).'</script>';
+        // Emit a single root object with an `@graph` list rather than a bare
+        // top-level array. A bare array has no `@context` key, which crashes
+        // Safari's structured-data parser (GH #177). The `@context` is declared
+        // once on the root and stripped from each node to avoid redundancy.
+        $document = [
+            '@context' => 'https://schema.org',
+            '@graph'   => array_map(static function (array $node): array {
+                unset($node['@context']);
+
+                return $node;
+            }, $graph),
+        ];
+
+        return '<script type="application/ld+json">'.json_encode($document).'</script>';
     }
 
     /**
@@ -327,7 +340,7 @@ class PageListener
     private function addSearchBar(): array
     {
         return [
-            '@context'        => 'http://schema.org',
+            '@context'        => 'https://schema.org',
             '@type'           => 'WebSite',
             'name'            => $this->settings->get('forum_title'),
             'url'             => $this->applicationUrl.'/',

--- a/tests/integration/ForumHtmlTestCase.php
+++ b/tests/integration/ForumHtmlTestCase.php
@@ -91,8 +91,10 @@ abstract class ForumHtmlTestCase extends TestCase
 
     /**
      * Parse the `<script type="application/ld+json">...</script>` block and
-     * return its decoded JSON content. The extension emits a single merged
-     * array, so the returned value is a list of top-level JSON-LD objects.
+     * return the list of schema.org nodes it contains. The extension emits a
+     * single root object with an `@graph` list of nodes (a bare array root
+     * crashes some consumers, e.g. Safari's structured-data parser), so unwrap
+     * `@graph` to the node list. A bare array is still accepted for resilience.
      *
      * @return array<int, array<string, mixed>>|null
      */
@@ -104,8 +106,16 @@ abstract class ForumHtmlTestCase extends TestCase
 
         $decoded = json_decode($matches[1], true);
 
-        // The extension always wraps multiple schema entries in a top-level array.
-        return is_array($decoded) ? $decoded : null;
+        if (!is_array($decoded)) {
+            return null;
+        }
+
+        // Single root object with `@graph` => the nodes live under `@graph`.
+        if (isset($decoded['@graph']) && is_array($decoded['@graph'])) {
+            return $decoded['@graph'];
+        }
+
+        return $decoded;
     }
 
     /**

--- a/tests/integration/forum/SchemaJsonLdTest.php
+++ b/tests/integration/forum/SchemaJsonLdTest.php
@@ -139,6 +139,36 @@ class SchemaJsonLdTest extends ForumHtmlTestCase
         $this->assertArrayNotHasKey('item', $items[3]);
     }
 
+    /**
+     * The block's root must be a single object carrying a string `@context`
+     * and an `@graph` list — never a bare array. A bare-array root makes
+     * `root["@context"]` undefined, crashing consumers that call
+     * `root["@context"].toLowerCase()` (e.g. Safari's parser). Regression lock
+     * for GH #177.
+     */
+    #[Test]
+    public function json_ld_root_is_a_graph_object_not_a_bare_array(): void
+    {
+        $html = $this->fetchForumHtml('/');
+
+        $this->assertSame(1, preg_match('/<script\s+type="application\/ld\+json"[^>]*>(.*?)<\/script>/is', $html, $matches));
+
+        $root = json_decode($matches[1], true);
+
+        $this->assertIsArray($root);
+        $this->assertArrayHasKey('@context', $root, 'Root must carry a top-level @context.');
+        // Canonical, current best-practice context: https, not http.
+        $this->assertSame('https://schema.org', $root['@context']);
+        $this->assertArrayHasKey('@graph', $root, 'Root must bundle nodes under @graph.');
+        $this->assertIsArray($root['@graph']);
+        $this->assertArrayNotHasKey(0, $root, 'Root must not be a bare list of nodes.');
+
+        // Nodes don't repeat `@context` (declared once on the root).
+        foreach ($root['@graph'] as $node) {
+            $this->assertArrayNotHasKey('@context', $node);
+        }
+    }
+
     #[Test]
     public function json_ld_block_is_always_valid_json(): void
     {


### PR DESCRIPTION
The JSON-LD block was emitted as a bare top-level array of schema.org nodes:

```json
[{"@context":"...","@type":"WebPage",...},{"@context":"...","@type":"WebSite",...}]
```

A bare array has no `@context` key, so Safari's structured-data parser throws when it reads the root and calls `root["@context"].toLowerCase()`.

**Fix:** emit a single root object with one `@context` and an `@graph` list of nodes — the spec-preferred way to bundle multiple entities — and drop the now-redundant per-node `@context`:

```json
{"@context":"https://schema.org","@graph":[{"@type":"WebPage",...},{"@type":"WebSite",...}]}
```

As this is the LTS branch, the root context is the canonical `https://schema.org`, and the two stale `http://schema.org` literals (WebPage / WebSite nodes) are normalised to https — the codebase is now consistently https.

The test helper unwraps `@graph` to the node list (still accepting a bare array for resilience), so existing schema assertions are unchanged. A regression test locks the object root (not a bare list), the `@graph` list, and the `https://schema.org` context.

Fixes #177