### PR TITLE
[2.x] fix: Detect primary tags by position, not the is_primary column

### DIFF
--- a/src/Breadcrumb/TagBreadcrumb.php
+++ b/src/Breadcrumb/TagBreadcrumb.php
@@ -53,7 +53,7 @@ class TagBreadcrumb
      */
     public function primaryLineages(Collection $tags): array
     {
-        $primary = $tags->filter(fn (Tag $tag) => (bool) $tag->is_primary);
+        $primary = $tags->filter(fn (Tag $tag) => $this->isHierarchical($tag));
 
         if ($primary->isEmpty()) {
             return [];
@@ -61,9 +61,9 @@ class TagBreadcrumb
 
         $attachedIds = $primary->map(fn (Tag $tag) => $tag->id)->all();
 
-        // A "leaf" is a primary tag that is not an ancestor of another attached
-        // primary tag — i.e. the most specific tag on each branch. This folds a
-        // primary parent + its attached primary child into a single lineage.
+        // A "leaf" is a hierarchical tag that is not an ancestor of another
+        // attached hierarchical tag — i.e. the most specific tag on each branch.
+        // This folds a parent + its attached child into a single lineage.
         $parentIds = $primary
             ->map(fn (Tag $tag) => $tag->parent_id)
             ->filter(fn (?int $id) => $id !== null && in_array($id, $attachedIds, true))
@@ -74,7 +74,10 @@ class TagBreadcrumb
         $lineages = [];
 
         foreach ($leaves as $leaf) {
-            $crumbs = [new Crumb('Tags', $this->url->to('forum')->route('tags'), 'CollectionPage')];
+            // The lineage is the pure tag chain (root → leaf). The "Tags" root
+            // crumb is only used on tag pages (see pushAncestorsOf), not on
+            // discussion trails, which read Forum › {tag lineage} › {title}.
+            $crumbs = [];
 
             foreach ($this->lineage($leaf) as $tag) {
                 $crumbs[] = $this->crumbFor($tag);
@@ -84,6 +87,20 @@ class TagBreadcrumb
         }
 
         return $lineages;
+    }
+
+    /**
+     * Whether a tag is part of the navigable tag hierarchy (and so belongs in a
+     * breadcrumb path). Mirrors core's own definition — a primary tag has a
+     * `position` and no parent; a child tag has a parent — rather than the
+     * legacy `is_primary` column, which can drift out of sync on older forums
+     * (e.g. discuss.flarum.org, where every top-level tag has `is_primary = 0`
+     * but a non-null `position`). Secondary tags (no position, no parent) are
+     * flat labels and excluded.
+     */
+    private function isHierarchical(Tag $tag): bool
+    {
+        return $tag->parent_id !== null || $tag->position !== null;
     }
 
     /**

--- a/tests/integration/forum/BreadcrumbTest.php
+++ b/tests/integration/forum/BreadcrumbTest.php
@@ -144,7 +144,7 @@ class BreadcrumbTest extends ForumHtmlTestCase
         ]);
 
         $this->assertSame(
-            ['My Forum', 'Tags', 'Support', 'Installation', 'How do I install?'],
+            ['My Forum', 'Support', 'Installation', 'How do I install?'],
             $this->crumbNames($this->fetchForumHtml('/d/1-how-install'))
         );
     }
@@ -156,7 +156,8 @@ class BreadcrumbTest extends ForumHtmlTestCase
 
         $this->prepareDatabase([
             Tag::class => [
-                ['id' => 1, 'name' => 'Chatter', 'slug' => 'chatter', 'description' => null, 'color' => '#000', 'position' => 0, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => false],
+                // Chatter is secondary (no position); Support is primary.
+                ['id' => 1, 'name' => 'Chatter', 'slug' => 'chatter', 'description' => null, 'color' => '#000', 'position' => null, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => false],
                 ['id' => 2, 'name' => 'Support', 'slug' => 'support', 'description' => null, 'color' => '#000', 'position' => 1, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => true],
             ],
             Discussion::class => [
@@ -173,7 +174,7 @@ class BreadcrumbTest extends ForumHtmlTestCase
 
         // The primary tag (Support) forms the lineage, not the secondary one.
         $this->assertSame(
-            ['My Forum', 'Tags', 'Support', 'Mixed'],
+            ['My Forum', 'Support', 'Mixed'],
             $this->crumbNames($this->fetchForumHtml('/d/1-mixed'))
         );
     }
@@ -197,7 +198,7 @@ class BreadcrumbTest extends ForumHtmlTestCase
         ]);
 
         $this->assertSame(
-            ['My Forum', 'Tags', 'Support', 'Q'],
+            ['My Forum', 'Support', 'Q'],
             $this->crumbNames($this->fetchForumHtml('/d/1-q'))
         );
     }
@@ -232,7 +233,7 @@ class BreadcrumbTest extends ForumHtmlTestCase
         $lists = array_filter($this->findSchemaJsonLd($html) ?? [], fn ($e) => ($e['@type'] ?? null) === 'BreadcrumbList');
         $this->assertCount(1, $lists);
         $this->assertSame(
-            ['My Forum', 'Tags', 'Support', 'Installation', 'Q'],
+            ['My Forum', 'Support', 'Installation', 'Q'],
             $this->crumbNames($html)
         );
     }
@@ -271,8 +272,8 @@ class BreadcrumbTest extends ForumHtmlTestCase
 
         $trails = array_map(fn ($l) => array_column($l['itemListElement'], 'name'), $lists);
 
-        $this->assertContains(['My Forum', 'Tags', 'Support', 'Q'], $trails);
-        $this->assertContains(['My Forum', 'Tags', 'Bugs', 'Q'], $trails);
+        $this->assertContains(['My Forum', 'Support', 'Q'], $trails);
+        $this->assertContains(['My Forum', 'Bugs', 'Q'], $trails);
     }
 
     #[Test]
@@ -284,7 +285,8 @@ class BreadcrumbTest extends ForumHtmlTestCase
         // Home › title, and there is a single BreadcrumbList.
         $this->prepareDatabase([
             Tag::class => [
-                ['id' => 1, 'name' => 'Announcements', 'slug' => 'announcements', 'description' => null, 'color' => '#000', 'position' => 0, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => false],
+                // A genuine secondary tag has no position (and no parent).
+                ['id' => 1, 'name' => 'Announcements', 'slug' => 'announcements', 'description' => null, 'color' => '#000', 'position' => null, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => false],
             ],
             Discussion::class => [
                 ['id' => 1, 'title' => 'Q', 'slug' => 'q', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'created_at' => Carbon::now()],
@@ -302,6 +304,40 @@ class BreadcrumbTest extends ForumHtmlTestCase
 
         $lists = array_filter($this->findSchemaJsonLd($html) ?? [], fn ($e) => ($e['@type'] ?? null) === 'BreadcrumbList');
         $this->assertCount(1, $lists);
+    }
+
+    #[Test]
+    public function a_top_level_tag_with_a_drifted_is_primary_flag_still_forms_the_lineage(): void
+    {
+        $this->extension('flarum-tags');
+
+        // Regression for discuss.flarum.org: top-level tags there have a
+        // `position` but a legacy `is_primary = 0`. The category must still
+        // appear in the breadcrumb — we key off `position`, not `is_primary`.
+        $this->prepareDatabase([
+            Tag::class => [
+                ['id' => 1, 'name' => 'Extensions', 'slug' => 'extensions', 'description' => null, 'color' => '#000', 'position' => 2, 'parent_id' => null, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => false],
+                // Genuinely-secondary version tags (no position).
+                ['id' => 2, 'name' => '2.x', 'slug' => 'version-2x', 'description' => null, 'color' => '#000', 'position' => null, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => false],
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'FoF Anti-Spam', 'slug' => 'antispam', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'created_at' => Carbon::now()],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Body.</p></t>', 'created_at' => Carbon::now()],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => 1],
+                ['discussion_id' => 1, 'tag_id' => 2],
+            ],
+        ]);
+
+        // Forum › Extensions › title — Extensions (positioned) anchors it; the
+        // secondary "2.x" tag is excluded.
+        $this->assertSame(
+            ['My Forum', 'Extensions', 'FoF Anti-Spam'],
+            $this->crumbNames($this->fetchForumHtml('/d/1-antispam'))
+        );
     }
 
     #[Test]

--- a/tests/integration/forum/SchemaJsonLdTest.php
+++ b/tests/integration/forum/SchemaJsonLdTest.php
@@ -125,18 +125,19 @@ class SchemaJsonLdTest extends ForumHtmlTestCase
         $this->assertNotNull($breadcrumb, 'Expected a BreadcrumbList entry when tags are present.');
 
         $items = $breadcrumb['itemListElement'] ?? [];
-        // Home › Tags › Baking › {discussion title}.
+        // Home › Baking › {discussion title} — the "Tags" listing crumb is only
+        // used on tag pages, not discussion trails.
         $names = array_column($items, 'name');
-        $this->assertSame(['My Forum', 'Tags', 'Baking', 'Help with bread'], $names);
+        $this->assertSame(['My Forum', 'Baking', 'Help with bread'], $names);
 
         // Positions are sequential from 1.
-        $this->assertSame([1, 2, 3, 4], array_column($items, 'position'));
+        $this->assertSame([1, 2, 3], array_column($items, 'position'));
 
         // The tag crumb links to the tag page...
-        $this->assertSame('http://localhost/t/baking', $items[2]['item']['url'] ?? null);
+        $this->assertSame('http://localhost/t/baking', $items[1]['item']['url'] ?? null);
         // ...and the last crumb (the discussion) omits `item` so Google uses
         // the page URL.
-        $this->assertArrayNotHasKey('item', $items[3]);
+        $this->assertArrayNotHasKey('item', $items[2]);
     }
 
     /**

--- a/tests/unit/Breadcrumb/TagBreadcrumbTest.php
+++ b/tests/unit/Breadcrumb/TagBreadcrumbTest.php
@@ -14,6 +14,7 @@ namespace FoF\Seo\Tests\unit\Breadcrumb;
 use Flarum\Http\RouteCollectionUrlGenerator;
 use Flarum\Http\UrlGenerator;
 use Flarum\Tags\Tag;
+use FoF\Seo\Breadcrumb\BreadcrumbTrail;
 use FoF\Seo\Breadcrumb\Crumb;
 use FoF\Seo\Breadcrumb\TagBreadcrumb;
 use Illuminate\Support\Collection;
@@ -56,18 +57,45 @@ class TagBreadcrumbTest extends TestCase
     /**
      * Build a Tag without touching the database. `parent` is wired as a loaded
      * relation so lineage() walks it without a query.
+     *
+     * A tag is "primary" (part of the navigable hierarchy) when it has a
+     * `position` and no parent — mirroring core (flarum/tags Content/Tags.php).
+     * The legacy `is_primary` column is deliberately decoupled here (defaults to
+     * the inverse-ish reality on old forums) so the tests prove we key off
+     * `position`, not `is_primary`.
      */
-    private function tag(int $id, string $name, bool $primary, ?Tag $parent = null): Tag
+    private function tag(int $id, string $name, ?int $position = null, ?Tag $parent = null, ?bool $isPrimary = null): Tag
     {
         $tag = new Tag();
         $tag->id = $id;
         $tag->name = $name;
         $tag->slug = strtolower($name);
-        $tag->is_primary = $primary;
+        $tag->position = $position;
         $tag->parent_id = $parent?->id;
         $tag->setRelation('parent', $parent);
+        // is_primary is intentionally NOT what we filter on; default it to the
+        // opposite of reality to catch any accidental reliance on it.
+        $tag->is_primary = $isPrimary ?? false;
 
         return $tag;
+    }
+
+    /** A top-level primary tag (has a position, no parent). */
+    private function primary(int $id, string $name, int $position = 0): Tag
+    {
+        return $this->tag($id, $name, $position, null);
+    }
+
+    /** A child tag (has a parent); position within the parent is irrelevant here. */
+    private function child(int $id, string $name, Tag $parent): Tag
+    {
+        return $this->tag($id, $name, 0, $parent);
+    }
+
+    /** A secondary tag (no position, no parent). */
+    private function secondary(int $id, string $name): Tag
+    {
+        return $this->tag($id, $name, null, null);
     }
 
     /**
@@ -84,8 +112,8 @@ class TagBreadcrumbTest extends TestCase
     public function no_primary_tags_yields_no_lineages(): void
     {
         $tags = [
-            $this->tag(1, 'Announcements', false),
-            $this->tag(2, 'Off-topic', false),
+            $this->secondary(1, 'Announcements'),
+            $this->secondary(2, 'Off-topic'),
         ];
 
         $this->assertSame([], $this->tagBreadcrumb($tags)->primaryLineages(new Collection($tags)));
@@ -94,68 +122,108 @@ class TagBreadcrumbTest extends TestCase
     #[Test]
     public function a_single_primary_tag_yields_one_lineage(): void
     {
-        $tags = [$this->tag(1, 'Support', true)];
+        $tags = [$this->primary(1, 'Support')];
 
         $lineages = $this->tagBreadcrumb($tags)->primaryLineages(new Collection($tags));
 
         $this->assertCount(1, $lineages);
-        $this->assertSame(['Tags', 'Support'], $this->names($lineages[0]));
+        // A lineage is the pure tag chain — no "Tags" root (that belongs to the
+        // tag-page trail, not discussion trails).
+        $this->assertSame(['Support'], $this->names($lineages[0]));
+    }
+
+    #[Test]
+    public function it_uses_position_not_the_is_primary_column(): void
+    {
+        // Regression for discuss.flarum.org: top-level tags there have a
+        // `position` but a drifted `is_primary = 0`. They must still anchor the
+        // breadcrumb, so we key off position, never is_primary.
+        $extensions = $this->tag(48, 'Extensions', position: 2, parent: null, isPrimary: false);
+
+        $lineages = $this->tagBreadcrumb([$extensions])->primaryLineages(new Collection([$extensions]));
+
+        $this->assertCount(1, $lineages);
+        $this->assertSame(['Extensions'], $this->names($lineages[0]));
+    }
+
+    #[Test]
+    public function a_positionless_tag_is_secondary_even_if_is_primary_is_true(): void
+    {
+        // The inverse drift: is_primary=1 but no position. Core treats this as
+        // secondary (no position ⇒ not in the primary nav), so we must too.
+        $weird = $this->tag(1, 'Legacy', position: null, parent: null, isPrimary: true);
+
+        $this->assertSame([], $this->tagBreadcrumb([$weird])->primaryLineages(new Collection([$weird])));
     }
 
     #[Test]
     public function a_primary_parent_and_child_fold_into_one_lineage(): void
     {
-        $support = $this->tag(1, 'Support', true);
-        $install = $this->tag(2, 'Installation', true, $support);
+        $support = $this->primary(1, 'Support');
+        $install = $this->child(2, 'Installation', $support);
         $tags = [$support, $install];
 
         // Both attached; order shouldn't matter.
         $lineages = $this->tagBreadcrumb($tags)->primaryLineages(new Collection($tags));
 
         $this->assertCount(1, $lineages);
-        $this->assertSame(['Tags', 'Support', 'Installation'], $this->names($lineages[0]));
+        $this->assertSame(['Support', 'Installation'], $this->names($lineages[0]));
     }
 
     #[Test]
     public function a_child_attached_without_its_parent_still_lists_ancestors(): void
     {
-        $support = $this->tag(1, 'Support', true);
-        $install = $this->tag(2, 'Installation', true, $support);
+        $support = $this->primary(1, 'Support');
+        $install = $this->child(2, 'Installation', $support);
 
         // Only the child is attached; its ancestor (present in the full tag
         // set) must still appear.
         $lineages = $this->tagBreadcrumb([$support, $install])->primaryLineages(new Collection([$install]));
 
         $this->assertCount(1, $lineages);
-        $this->assertSame(['Tags', 'Support', 'Installation'], $this->names($lineages[0]));
+        $this->assertSame(['Support', 'Installation'], $this->names($lineages[0]));
     }
 
     #[Test]
     public function two_unrelated_primary_tags_yield_two_lineages(): void
     {
         $tags = [
-            $this->tag(1, 'Support', true),
-            $this->tag(2, 'Bugs', true),
+            $this->primary(1, 'Support', 0),
+            $this->primary(2, 'Bugs', 1),
         ];
 
         $lineages = $this->tagBreadcrumb($tags)->primaryLineages(new Collection($tags));
 
         $this->assertCount(2, $lineages);
-        $this->assertSame(['Tags', 'Support'], $this->names($lineages[0]));
-        $this->assertSame(['Tags', 'Bugs'], $this->names($lineages[1]));
+        $this->assertSame(['Support'], $this->names($lineages[0]));
+        $this->assertSame(['Bugs'], $this->names($lineages[1]));
     }
 
     #[Test]
     public function secondary_tags_are_excluded_when_mixed_with_a_primary(): void
     {
         $tags = [
-            $this->tag(1, 'Chatter', false),
-            $this->tag(2, 'Support', true),
+            $this->secondary(1, 'Chatter'),
+            $this->primary(2, 'Support'),
         ];
 
         $lineages = $this->tagBreadcrumb($tags)->primaryLineages(new Collection($tags));
 
         $this->assertCount(1, $lineages);
-        $this->assertSame(['Tags', 'Support'], $this->names($lineages[0]));
+        $this->assertSame(['Support'], $this->names($lineages[0]));
+    }
+
+    #[Test]
+    public function tag_page_ancestor_trail_keeps_the_tags_root(): void
+    {
+        $support = $this->primary(1, 'Support');
+        $install = $this->child(2, 'Installation', $support);
+
+        $trail = new BreadcrumbTrail();
+        $this->tagBreadcrumb([$support, $install])->pushAncestorsOf($trail, $install);
+
+        // Tag pages still root at the /tags listing, then the ancestors (the tag
+        // itself is added by the caller as the current crumb).
+        $this->assertSame(['Tags', 'Support'], $this->names($trail->all()));
     }
 }


### PR DESCRIPTION
## Problem

On some forums every discussion's breadcrumb collapses to `Forum › Title`, dropping the tag/category. Confirmed on discuss.flarum.org, where all top-level tags have a `position` but `is_primary = 0`.

## Cause

`TagBreadcrumb` decided which tags form the breadcrumb path using the `is_primary` column. That column is newer than the position-based model and only gets re-set when tag order is saved through the admin UI, so it can drift to 0 on top-level tags while `position` stays correct. Core itself defines a primary tag by `position !== null` (see flarum/tags `Content/Tags.php`, `GlobalPolicy`).

## Fix

- Classify primary tags by `position !== null` (plus child tags via `parent_id`), matching core, instead of `is_primary`.
- Drop the `Tags` root crumb from discussion trails (still shown on tag pages).

## Tests

Unit and integration coverage updated, including a regression for the drifted-`is_primary` case. Full suite + PHPStan pass.