### PR TITLE
Guard the tag lineage walk in a unit test instead of a query count

### DIFF
--- a/tests/integration/forum/BreadcrumbTest.php
+++ b/tests/integration/forum/BreadcrumbTest.php
@@ -428,50 +428,74 @@ class BreadcrumbTest extends ForumHtmlTestCase
     {
         $this->extension('flarum-tags');
 
-        // Two tagged discussions: one in a shallow (1-level) primary tag, one in
-        // a deep (3-level) primary chain. Comparing *tagged vs tagged* isolates
-        // the cost of walking the tag lineage from the one-time tag-loading
-        // overhead (which varies by DB driver). Core eager-loads the tag
-        // ancestry, so walking deeper levels must add no queries.
+        // Two primary chains, 3 and 9 levels deep, each with one discussion on
+        // its leaf tag.
+        //
+        // Both pages are *deep* and tagged, so every fixed cost — loading tags,
+        // serializing the discussion, this extension's own one-time setup —
+        // appears in both counts and cancels out. What remains is the marginal
+        // cost of the 6 extra ancestor levels, which is what a breadcrumb N+1
+        // would show up in.
+        $shallowDepth = 3;
+        $deepDepth = 9;
+
+        $tags = [];
+        $discussions = [];
+        $posts = [];
+        $pivot = [];
+        $id = 0;
+
+        foreach ([1 => $shallowDepth, 2 => $deepDepth] as $discussionId => $depth) {
+            $parent = null;
+
+            for ($level = 1; $level <= $depth; $level++) {
+                $id++;
+                $tags[] = ['id' => $id, 'name' => "D{$depth}L{$level}", 'slug' => "d{$depth}l{$level}", 'description' => null, 'color' => '#000', 'position' => 0, 'parent_id' => $parent, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => true];
+                $parent = $id;
+            }
+
+            $discussions[] = ['id' => $discussionId, 'title' => "Depth {$depth}", 'slug' => "depth-{$depth}", 'user_id' => 1, 'first_post_id' => $discussionId, 'comment_count' => 1, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now()];
+            $posts[] = ['id' => $discussionId, 'discussion_id' => $discussionId, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Body.</p></t>', 'created_at' => Carbon::now()];
+            $pivot[] = ['discussion_id' => $discussionId, 'tag_id' => $id];
+        }
+
         $this->prepareDatabase([
-            Tag::class => [
-                ['id' => 1, 'name' => 'Shallow', 'slug' => 'shallow', 'description' => null, 'color' => '#000', 'position' => 0, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => true],
-                ['id' => 2, 'name' => 'L1', 'slug' => 'l1', 'description' => null, 'color' => '#000', 'position' => 0, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => true],
-                ['id' => 3, 'name' => 'L2', 'slug' => 'l2', 'description' => null, 'color' => '#000', 'position' => 0, 'parent_id' => 2, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => true],
-                ['id' => 4, 'name' => 'L3', 'slug' => 'l3', 'description' => null, 'color' => '#000', 'position' => 0, 'parent_id' => 3, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => true],
-            ],
-            Discussion::class => [
-                ['id' => 1, 'title' => 'Shallow tagged', 'slug' => 'shallow-tagged', 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now()],
-                ['id' => 2, 'title' => 'Deep tagged', 'slug' => 'deep-tagged', 'user_id' => 1, 'first_post_id' => 2, 'comment_count' => 1, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now()],
-            ],
-            Post::class => [
-                ['id' => 1, 'discussion_id' => 1, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Body.</p></t>', 'created_at' => Carbon::now()],
-                ['id' => 2, 'discussion_id' => 2, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Body.</p></t>', 'created_at' => Carbon::now()],
-            ],
-            'discussion_tag' => [
-                ['discussion_id' => 1, 'tag_id' => 1], // shallow: 1 level
-                ['discussion_id' => 2, 'tag_id' => 4], // deep: 3 levels (L1 > L2 > L3)
-            ],
+            Tag::class        => $tags,
+            Discussion::class => $discussions,
+            Post::class       => $posts,
+            'discussion_tag'  => $pivot,
         ]);
 
-        // Warm one-time caches before measuring.
+        // Hit both routes before measuring. The forum index alone does not warm
+        // everything a discussion page touches, so whichever discussion was
+        // measured first used to absorb several one-time queries — enough to
+        // swing the delta by more than the tolerance and make this test flaky.
         $this->fetchForumHtml('/');
+        $this->countQueriesFor('/d/1-depth-'.$shallowDepth);
+        $this->countQueriesFor('/d/2-depth-'.$deepDepth);
 
-        $shallow = $this->countQueriesFor('/d/1-shallow-tagged');
-        $deep = $this->countQueriesFor('/d/2-deep-tagged');
+        $shallow = $this->countQueriesFor('/d/1-depth-'.$shallowDepth);
+        $deep = $this->countQueriesFor('/d/2-depth-'.$deepDepth);
 
-        // Our breadcrumb code walks the tag ancestry against an in-memory map,
-        // so it adds NO queries per tag level (verified: commenting out the
-        // breadcrumb call leaves the same delta). Core itself lazy-loads
-        // `tags.parent` one extra level deep when serializing the discussion's
-        // tags, which is outside this extension's control — so allow a small
-        // constant slack, but guard hard against the per-level growth a real
-        // breadcrumb N+1 would show (which would scale with the 2 extra levels
-        // here, and far more on deeper chains).
+        $extraLevels = $deepDepth - $shallowDepth;
+        $delta = $deep - $shallow;
+
+        // Our lineage walk resolves ancestors against an in-memory map of all
+        // tags, so it costs nothing per level. Core is not free: serializing the
+        // tags lazy-loads `parent` once per ancestor, roughly one query per
+        // extra level, and that is outside this extension's control.
+        //
+        // So budget for core's one-per-level plus a few queries of driver
+        // variance. Our walk lazy-loading alongside core's would roughly double
+        // the figure, which this catches with room to spare. A stricter constant
+        // cannot work here: it would just track core's current behaviour rather
+        // than ours.
+        $budget = $extraLevels + 3;
+
         $this->assertLessThanOrEqual(
-            2,
-            $deep - $shallow,
-            'Deep tag chain issued '.($deep - $shallow).' more queries than a shallow one — a per-level breadcrumb N+1 has crept in.'
+            $budget,
+            $delta,
+            "A {$deepDepth}-level tag chain issued {$delta} more queries than a {$shallowDepth}-level one over {$extraLevels} extra levels, above the budget of {$budget} — a per-level breadcrumb N+1 has crept in."
         );
     }
 }

--- a/tests/integration/forum/BreadcrumbTest.php
+++ b/tests/integration/forum/BreadcrumbTest.php
@@ -49,19 +49,6 @@ class BreadcrumbTest extends ForumHtmlTestCase
         return $breadcrumb === null ? [] : array_column($breadcrumb['itemListElement'], 'name');
     }
 
-    private function countQueriesFor(string $path): int
-    {
-        /** @var \Illuminate\Database\Connection $db */
-        $db = $this->database();
-        $db->flushQueryLog();
-        $db->enableQueryLog();
-        $this->fetchForumHtml($path);
-        $count = count($db->getQueryLog());
-        $db->disableQueryLog();
-
-        return $count;
-    }
-
     // ----- Core pages (no flarum/tags) -----------------------------------
 
     #[Test]
@@ -419,83 +406,5 @@ class BreadcrumbTest extends ForumHtmlTestCase
         $this->assertSame('My Forum', $items[0]['name']);
         $this->assertSame('http://localhost/', $items[0]['item']['url'] ?? null);
         $this->assertArrayNotHasKey('item', $items[1]);
-    }
-
-    // ----- Performance ----------------------------------------------------
-
-    #[Test]
-    public function building_the_tag_lineage_does_not_issue_per_level_queries(): void
-    {
-        $this->extension('flarum-tags');
-
-        // Two primary chains, 3 and 9 levels deep, each with one discussion on
-        // its leaf tag.
-        //
-        // Both pages are *deep* and tagged, so every fixed cost — loading tags,
-        // serializing the discussion, this extension's own one-time setup —
-        // appears in both counts and cancels out. What remains is the marginal
-        // cost of the 6 extra ancestor levels, which is what a breadcrumb N+1
-        // would show up in.
-        $shallowDepth = 3;
-        $deepDepth = 9;
-
-        $tags = [];
-        $discussions = [];
-        $posts = [];
-        $pivot = [];
-        $id = 0;
-
-        foreach ([1 => $shallowDepth, 2 => $deepDepth] as $discussionId => $depth) {
-            $parent = null;
-
-            for ($level = 1; $level <= $depth; $level++) {
-                $id++;
-                $tags[] = ['id' => $id, 'name' => "D{$depth}L{$level}", 'slug' => "d{$depth}l{$level}", 'description' => null, 'color' => '#000', 'position' => 0, 'parent_id' => $parent, 'is_restricted' => false, 'is_hidden' => false, 'is_primary' => true];
-                $parent = $id;
-            }
-
-            $discussions[] = ['id' => $discussionId, 'title' => "Depth {$depth}", 'slug' => "depth-{$depth}", 'user_id' => 1, 'first_post_id' => $discussionId, 'comment_count' => 1, 'created_at' => Carbon::now(), 'last_posted_at' => Carbon::now()];
-            $posts[] = ['id' => $discussionId, 'discussion_id' => $discussionId, 'number' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => '<t><p>Body.</p></t>', 'created_at' => Carbon::now()];
-            $pivot[] = ['discussion_id' => $discussionId, 'tag_id' => $id];
-        }
-
-        $this->prepareDatabase([
-            Tag::class        => $tags,
-            Discussion::class => $discussions,
-            Post::class       => $posts,
-            'discussion_tag'  => $pivot,
-        ]);
-
-        // Hit both routes before measuring. The forum index alone does not warm
-        // everything a discussion page touches, so whichever discussion was
-        // measured first used to absorb several one-time queries — enough to
-        // swing the delta by more than the tolerance and make this test flaky.
-        $this->fetchForumHtml('/');
-        $this->countQueriesFor('/d/1-depth-'.$shallowDepth);
-        $this->countQueriesFor('/d/2-depth-'.$deepDepth);
-
-        $shallow = $this->countQueriesFor('/d/1-depth-'.$shallowDepth);
-        $deep = $this->countQueriesFor('/d/2-depth-'.$deepDepth);
-
-        $extraLevels = $deepDepth - $shallowDepth;
-        $delta = $deep - $shallow;
-
-        // Our lineage walk resolves ancestors against an in-memory map of all
-        // tags, so it costs nothing per level. Core is not free: serializing the
-        // tags lazy-loads `parent` once per ancestor, roughly one query per
-        // extra level, and that is outside this extension's control.
-        //
-        // So budget for core's one-per-level plus a few queries of driver
-        // variance. Our walk lazy-loading alongside core's would roughly double
-        // the figure, which this catches with room to spare. A stricter constant
-        // cannot work here: it would just track core's current behaviour rather
-        // than ours.
-        $budget = $extraLevels + 3;
-
-        $this->assertLessThanOrEqual(
-            $budget,
-            $delta,
-            "A {$deepDepth}-level tag chain issued {$delta} more queries than a {$shallowDepth}-level one over {$extraLevels} extra levels, above the budget of {$budget} — a per-level breadcrumb N+1 has crept in."
-        );
     }
 }

--- a/tests/unit/Breadcrumb/TagBreadcrumbTest.php
+++ b/tests/unit/Breadcrumb/TagBreadcrumbTest.php
@@ -17,7 +17,9 @@ use Flarum\Tags\Tag;
 use FoF\Seo\Breadcrumb\BreadcrumbTrail;
 use FoF\Seo\Breadcrumb\Crumb;
 use FoF\Seo\Breadcrumb\TagBreadcrumb;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Collection;
+use LogicException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -182,6 +184,51 @@ class TagBreadcrumbTest extends TestCase
 
         $this->assertCount(1, $lineages);
         $this->assertSame(['Support', 'Installation'], $this->names($lineages[0]));
+    }
+
+    /**
+     * The ancestor walk must resolve parents from the in-memory tag map, never
+     * by touching `$tag->parent`. A per-level lazy load there is an N+1 that
+     * grows with chain depth.
+     *
+     * This is asserted here rather than by counting queries on a rendered page:
+     * core lazy-loads `parent` per ancestor level itself, and by an amount that
+     * varies by database driver, so a page-level query count cannot separate our
+     * cost from core's. Withholding the relation makes the invariant exact.
+     */
+    #[Test]
+    public function the_ancestor_walk_never_lazy_loads_a_parent(): void
+    {
+        $chain = [];
+        $parentId = null;
+
+        // A 9-level chain whose `parent` relation is deliberately NOT loaded, on
+        // models that fail loudly if the relation is touched at all.
+        for ($level = 1; $level <= 9; $level++) {
+            $tag = new class() extends Tag {
+                public function parent(): BelongsTo
+                {
+                    throw new LogicException('lineage() lazy-loaded a parent; it must resolve ancestors against the in-memory tag map.');
+                }
+            };
+
+            $tag->id = $level;
+            $tag->name = "L{$level}";
+            $tag->slug = "l{$level}";
+            $tag->position = 0;
+            $tag->parent_id = $parentId;
+            $tag->is_primary = false;
+
+            $chain[] = $tag;
+            $parentId = $level;
+        }
+
+        $leaf = $chain[count($chain) - 1];
+
+        $lineages = $this->tagBreadcrumb($chain)->primaryLineages(new Collection([$leaf]));
+
+        $this->assertCount(1, $lineages);
+        $this->assertSame(['L1', 'L2', 'L3', 'L4', 'L5', 'L6', 'L7', 'L8', 'L9'], $this->names($lineages[0]));
     }
 
     #[Test]


### PR DESCRIPTION
`BreadcrumbTest::building_the_tag_lineage_does_not_issue_per_level_queries` fails intermittently. It moves between matrix jobs rather than sticking to one driver — MySQL 8.0 on one attempt, SQLite on a re-run of the same commit — and it reproduces on a plain `2.x` dispatch, so it is not tied to any recent change.

It counted queries for a whole rendered page and compared a shallow tag chain against a deep one, tolerating a delta of 2. That cannot work, for two reasons.

**The page count is dominated by costs that are not ours.** Instrumenting the query log by chain depth with fof/seo disabled entirely:

```
depth 1: 0 single-tag lookups
depth 3: 2
depth 5: 4
depth 9: 8
```

That is core lazy-loading `parent` once per ancestor level while serializing the discussion's tags. It happens with this extension switched off, so the tolerance of 2 was really just tracking core's number.

**The baseline varies by driver, by more than the signal.** Measuring the marginal cost of 6 extra levels: SQLite reports 6, PostgreSQL reports 10. A per-level lazy load in our own walk would add roughly one query per level, so on SQLite it would total 12 — under any budget wide enough to let PostgreSQL's 10 through. The ranges overlap, so no cross-driver constant separates our cost from core's. I tried a warmed, deep-vs-deep version with a per-level budget first; PostgreSQL still failed it at 10 against 9, which is what made the overlap obvious.

So the invariant is now asserted where it can be exact. `TagBreadcrumbTest::the_ancestor_walk_never_lazy_loads_a_parent` builds a 9-level chain whose `parent` relation is deliberately left unloaded, on models that throw if it is touched. `lineage()` resolves ancestors from the in-memory tag map, so the walk completes; a regression to `$tag->parent` throws with a clear message. No database, no driver variance, no tolerance to tune.

Verified by reverting the walk to `$current->parent`, which fails the new test:

```
LogicException: lineage() lazy-loaded a parent; it must resolve ancestors
against the in-memory tag map.
```

The integration test is removed along with its now-unused `countQueriesFor()` helper. That does drop end-to-end coverage of the query count, which is worth a look on review — my reading is that it was measuring core's behaviour rather than ours and could not be made reliable, but the call is yours.

Core's per-level `parent` lazy-load is a genuine N+1 on deep tag chains (8 extra queries on a 9-level chain) that no extension can fix from outside. Not addressed here.
