### PR TITLE
[2.x] Warm both routes before counting queries in the Q&A N+1 guard

### DIFF
--- a/tests/integration/forum/BestAnswerPageTest.php
+++ b/tests/integration/forum/BestAnswerPageTest.php
@@ -593,12 +593,23 @@ class BestAnswerPageTest extends ForumHtmlTestCase
         $this->seedQnaWithAnswers(1, 'small', 2);
         $this->seedQnaWithAnswers(2, 'large', 8);
 
-        // Warm one-time caches (settings, permissions, etc.) before measuring.
+        // Warm both discussion routes, not just the index. A discussion page
+        // touches caches the index does not, so the first *discussion* measured
+        // absorbs a handful of one-time queries — locally 57 on the first pass
+        // and 53 on every pass after. That swing is larger than the tolerance
+        // below, so whichever page happened to go first decided whether this
+        // test passed, which made it flaky.
         $this->fetchForumHtml('/');
+        $this->countQueriesFor('/d/1-small');
+        $this->countQueriesFor('/d/2-large');
 
         $small = $this->countQueriesFor('/d/1-small');
         $large = $this->countQueriesFor('/d/2-large');
 
+        // Measured warm, the count is flat in the number of answers: 2, 4, 8 and
+        // 16 answers all render in the same number of queries, so the expected
+        // delta is 0. The tolerance is slack for incidental variance, well under
+        // the 6 extra queries an N+1 over the 6 extra answers would cost.
         $this->assertLessThanOrEqual(
             3,
             $large - $small,


### PR DESCRIPTION
`BestAnswerPageTest::qa_page_does_not_issue_per_answer_queries` failed on `2.x` (PHP 8.3 / MySQL 8.0) with a delta of 4 against a tolerance of 3, having passed on the branch run of the same code shortly before.

The guard itself is sound — the invariant it protects genuinely holds. Rendering the Q&A page takes the same number of queries regardless of how many answers there are:

```
answers:  2    4    8    16
queries: 53   53   53   53
```

The problem was the warm-up. It warmed the forum index and then measured the two discussion pages, but a discussion page touches caches the index does not, so the first *discussion* measured absorbed the one-time cost: 57 queries on the first pass, 53 on every pass after. A 4-query swing against a tolerance of 3 meant whichever page happened to go first decided the result. Measuring the small page first hid it; when the cost landed on the large page instead, the delta went positive and the test failed.

So both routes are now hit before measuring. Warm, the delta is 0 and stable — three consecutive local runs pass.

The tolerance of 3 stays. It is no longer absorbing warm-up, just incidental variance, and it sits well below the 6 extra queries an N+1 over the 6 extra answers would cost. Verified by adding a deliberate per-answer query to the answers loop in `DiscussionBestAnswerPage`, which fails the test:

```
Query count grew by 6 between a 2-answer and an 8-answer Q&A page — looks like an N+1 over answer posts.
```

This was the last query-counting test in the suite, after #186 replaced the tag lineage one.
